### PR TITLE
feat: build inventory table with sort, filter, and search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "gray-matter": "^4.0.3",
@@ -2537,6 +2538,39 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,86 @@
-import { Button } from "@/components/ui/button";
+"use client";
+
+import * as React from "react";
+import type { ScanResponse, ScanErrorResponse } from "@/app/api/scan/route";
+import type { SkillFile } from "@/lib/types";
+import { InventoryTable } from "@/components/inventory-table";
 
 export default function Home() {
+  const [skills, setSkills] = React.useState<SkillFile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [scannedAt, setScannedAt] = React.useState<string | undefined>();
+  const [scanDurationMs, setScanDurationMs] = React.useState<
+    number | undefined
+  >();
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    async function fetchScan() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch("/api/scan");
+        const json = (await res.json()) as ScanResponse | ScanErrorResponse;
+
+        if (cancelled) return;
+
+        if (!res.ok || "error" in json) {
+          const errJson = json as ScanErrorResponse;
+          setError(errJson.error ?? "Scan failed");
+          setSkills([]);
+          return;
+        }
+
+        const data = json as ScanResponse;
+        const allSkills: SkillFile[] = [
+          ...data.userSkills,
+          ...data.pluginSkills,
+          ...data.projects.flatMap((p) => p.skills),
+        ];
+
+        setSkills(allSkills);
+        setScannedAt(data.scannedAt);
+        setScanDurationMs(data.scanDurationMs);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Network error");
+        setSkills([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchScan();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
-    <div className="flex flex-1 flex-col items-center justify-center min-h-screen bg-background px-4">
-      <main className="flex flex-col items-center gap-6 text-center max-w-lg">
-        <h1 className="text-4xl font-bold tracking-tight">Skill Lens</h1>
-        <p className="text-lg text-muted-foreground">
+    <div className="flex flex-col min-h-screen bg-background">
+      <header className="border-b px-6 py-4">
+        <h1 className="text-2xl font-bold tracking-tight">Skill Lens</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
           Visualize and analyze Claude Code skills across all your projects.
         </p>
-        <p className="text-sm text-muted-foreground">
-          Skill inventory, overlap detection, and gap analysis — coming soon.
-        </p>
-        <Button disabled>Scan Projects</Button>
+      </header>
+
+      <main className="flex-1 px-6 py-6 max-w-screen-2xl w-full mx-auto">
+        {error ? (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            <strong>Scan error:</strong> {error}
+          </div>
+        ) : (
+          <InventoryTable
+            data={skills}
+            loading={loading}
+            scannedAt={scannedAt}
+            scanDurationMs={scanDurationMs}
+          />
+        )}
       </main>
     </div>
   );

--- a/src/components/inventory-table.tsx
+++ b/src/components/inventory-table.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import * as React from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  flexRender,
+  createColumnHelper,
+  type SortingState,
+  type ColumnFiltersState,
+} from "@tanstack/react-table";
+import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+
+import type { SkillFile } from "@/lib/types";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface InventoryTableProps {
+  data: SkillFile[];
+  loading: boolean;
+  scannedAt?: string;
+  scanDurationMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Column helper
+// ---------------------------------------------------------------------------
+
+const columnHelper = createColumnHelper<SkillFile>();
+
+const columns = [
+  columnHelper.accessor("name", {
+    header: "Name",
+    cell: (info) => (
+      <span className="font-medium text-foreground">{info.getValue()}</span>
+    ),
+    enableSorting: true,
+  }),
+  columnHelper.accessor("type", {
+    header: "Type",
+    cell: (info) => {
+      const v = info.getValue();
+      const variant =
+        v === "skill"
+          ? "default"
+          : v === "agent"
+            ? "secondary"
+            : ("outline" as const);
+      return <Badge variant={variant}>{v}</Badge>;
+    },
+    enableSorting: true,
+    filterFn: "equals",
+  }),
+  columnHelper.accessor("level", {
+    header: "Level",
+    cell: (info) => {
+      const v = info.getValue();
+      const variant =
+        v === "user"
+          ? "outline"
+          : v === "project"
+            ? "secondary"
+            : ("default" as const);
+      return <Badge variant={variant}>{v}</Badge>;
+    },
+    enableSorting: true,
+    filterFn: "equals",
+  }),
+  columnHelper.accessor(
+    (row) => row.projectName ?? (row.level === "plugin" ? "(plugin)" : "(user)"),
+    {
+      id: "project",
+      header: "Project",
+      cell: (info) => (
+        <span className="text-muted-foreground">{info.getValue()}</span>
+      ),
+      enableSorting: true,
+      filterFn: "equals",
+    }
+  ),
+  columnHelper.accessor("description", {
+    header: "Description",
+    cell: (info) => (
+      <span className="text-muted-foreground line-clamp-2 max-w-xs">
+        {info.getValue() || <em className="opacity-50">—</em>}
+      </span>
+    ),
+    enableSorting: true,
+  }),
+  columnHelper.accessor(
+    (row) => (row.frontmatter.model as string | undefined) ?? "",
+    {
+      id: "model",
+      header: "Model",
+      cell: (info) =>
+        info.getValue() ? (
+          <span className="font-mono text-xs">{info.getValue()}</span>
+        ) : (
+          <span className="text-muted-foreground opacity-50">—</span>
+        ),
+      enableSorting: true,
+    }
+  ),
+  columnHelper.accessor(
+    (row) => (row.frontmatter.effort as string | undefined) ?? "",
+    {
+      id: "effort",
+      header: "Effort",
+      cell: (info) =>
+        info.getValue() ? (
+          <Badge variant="outline">{info.getValue()}</Badge>
+        ) : (
+          <span className="text-muted-foreground opacity-50">—</span>
+        ),
+      enableSorting: true,
+    }
+  ),
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function SortIcon({
+  sorted,
+}: {
+  sorted: false | "asc" | "desc";
+}) {
+  if (sorted === "asc") return <ArrowUp className="size-3.5 ml-1 inline-block" />;
+  if (sorted === "desc") return <ArrowDown className="size-3.5 ml-1 inline-block" />;
+  return <ArrowUpDown className="size-3.5 ml-1 inline-block opacity-40" />;
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function TableSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <Skeleton key={i} className="h-9 w-full" />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filter select helper
+// ---------------------------------------------------------------------------
+
+function FilterSelect({
+  placeholder,
+  value,
+  onValueChange,
+  options,
+}: {
+  placeholder: string;
+  value: string;
+  onValueChange: (v: string) => void;
+  options: string[];
+}) {
+  return (
+    <Select
+      value={value || "all"}
+      onValueChange={(v: string | null) => onValueChange(v ?? "all")}
+    >
+      <SelectTrigger className="w-36">
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">{placeholder}</SelectItem>
+        {options.map((opt) => (
+          <SelectItem key={opt} value={opt}>
+            {opt}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function InventoryTable({
+  data,
+  loading,
+  scannedAt,
+  scanDurationMs,
+}: InventoryTableProps) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    []
+  );
+  const [globalFilter, setGlobalFilter] = React.useState("");
+
+  // Derived filter values
+  const typeFilter =
+    (columnFilters.find((f) => f.id === "type")?.value as string) ?? "";
+  const levelFilter =
+    (columnFilters.find((f) => f.id === "level")?.value as string) ?? "";
+  const projectFilter =
+    (columnFilters.find((f) => f.id === "project")?.value as string) ?? "";
+
+  // Unique option lists
+  const projectOptions = React.useMemo(
+    () =>
+      Array.from(
+        new Set(
+          data.map(
+            (s) =>
+              s.projectName ?? (s.level === "plugin" ? "(plugin)" : "(user)")
+          )
+        )
+      ).sort(),
+    [data]
+  );
+
+  function setColumnFilter(id: string, value: string) {
+    setColumnFilters((prev) => {
+      const without = prev.filter((f) => f.id !== id);
+      if (!value || value === "all") return without;
+      return [...without, { id, value }];
+    });
+  }
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, columnFilters, globalFilter },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: (row, _columnId, filterValue: string) => {
+      const lower = filterValue.toLowerCase();
+      return (
+        row.original.name.toLowerCase().includes(lower) ||
+        row.original.description.toLowerCase().includes(lower)
+      );
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          placeholder="Search name or description…"
+          value={globalFilter}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          className="w-64"
+        />
+
+        <FilterSelect
+          placeholder="All types"
+          value={typeFilter}
+          onValueChange={(v) => setColumnFilter("type", v)}
+          options={["skill", "agent", "rule"]}
+        />
+
+        <FilterSelect
+          placeholder="All levels"
+          value={levelFilter}
+          onValueChange={(v) => setColumnFilter("level", v)}
+          options={["user", "project", "plugin"]}
+        />
+
+        <FilterSelect
+          placeholder="All projects"
+          value={projectFilter}
+          onValueChange={(v) => setColumnFilter("project", v)}
+          options={projectOptions}
+        />
+
+        <span className="ml-auto text-sm text-muted-foreground">
+          {loading
+            ? "Scanning…"
+            : `${table.getFilteredRowModel().rows.length} of ${data.length} items`}
+        </span>
+      </div>
+
+      {/* Scan metadata */}
+      {!loading && scannedAt && (
+        <p className="text-xs text-muted-foreground">
+          Scanned {formatTimestamp(scannedAt)}
+          {scanDurationMs !== undefined && ` in ${scanDurationMs}ms`}
+        </p>
+      )}
+
+      {/* Table */}
+      {loading ? (
+        <TableSkeleton />
+      ) : data.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
+          <p className="text-lg font-medium">No skills found</p>
+          <p className="text-sm mt-1">
+            Make sure you have skills, agents, or rules in your projects.
+          </p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : header.column.getCanSort() ? (
+                      <button
+                        type="button"
+                        className="flex items-center cursor-pointer select-none hover:text-foreground transition-colors"
+                        onClick={header.column.getToggleSortingHandler()}
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                        <SortIcon sorted={header.column.getIsSorted()} />
+                      </button>
+                    ) : (
+                      flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )
+                    )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="text-center text-muted-foreground py-10"
+                >
+                  No results match your filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## Summary

- Add `InventoryTable` component using `@tanstack/react-table` + shadcn/ui with columns: Name, Type, Level, Project, Description, Model, Effort
- Column sorting on all columns (click header toggles asc/desc), global search filtering name + description in real-time, and filter dropdowns for Type / Level / Project
- Loading skeleton (8 animated rows) while `/api/scan` runs; empty state with message if no skills found; row count indicator (`N of M items`)
- Replace landing `page.tsx` with a `"use client"` component that fetches `/api/scan` on mount, aggregates `userSkills + pluginSkills + project.skills` into a flat list, and displays scan timestamp + duration

## New files

- `src/components/inventory-table.tsx` — table component
- `src/components/ui/table.tsx` — shadcn table primitives
- `src/components/ui/input.tsx` — shadcn input
- `src/components/ui/badge.tsx` — shadcn badge
- `src/components/ui/select.tsx` — shadcn select
- `src/components/ui/skeleton.tsx` — shadcn skeleton

## Test plan

- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] `npm run lint` passes (1 expected warning from React Compiler about `useReactTable`, no errors)
- [ ] `npm test` passes (67/67 tests)
- [ ] `npm run build` succeeds
- [ ] Table renders all scanned files when `/api/scan` returns data
- [ ] All columns sortable by clicking header
- [ ] Global search filters by name + description in real-time
- [ ] Type/Level/Project filter dropdowns narrow rows correctly
- [ ] Loading skeleton visible while scan runs
- [ ] Empty state shown when no skills found

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
