### PR TITLE
feat: add Open in Editor action for skill files (#8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "gray-matter": "^4.0.3",
         "lucide-react": "^1.7.0",
         "next": "16.2.2",
+        "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "shadcn": "^4.1.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -7829,6 +7831,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -9323,6 +9335,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "gray-matter": "^4.0.3",
     "lucide-react": "^1.7.0",
     "next": "16.2.2",
+    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.1.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/src/app/api/open/route.test.ts
+++ b/src/app/api/open/route.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Integration tests for POST /api/open
+ *
+ * AC1: "Path validation prevents arbitrary file access" → integration (API route handler)
+ * AC2: "Opens file in default editor on Windows/Mac/Linux" → integration (mocked child_process)
+ * AC3: "Returns 200 on success, 400 on invalid path, 403 on out-of-bounds path" → integration
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock child_process exec
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+// Mock the scanner discover module for path validation
+vi.mock('@/lib/scanner/discover', () => ({
+  discoverProjects: vi.fn(),
+}));
+
+// Mock os module for platform detection
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return {
+    ...actual,
+    platform: vi.fn(() => 'linux'),
+    homedir: vi.fn(() => '/home/testuser'),
+  };
+});
+
+import { exec } from 'child_process';
+import { discoverProjects } from '@/lib/scanner/discover';
+import { POST } from './route';
+
+// exec has complex overloads — cast to a simple callable for mocking
+const mockExec = vi.mocked(exec) as unknown as ReturnType<typeof vi.fn>;
+const mockDiscoverProjects = vi.mocked(discoverProjects);
+
+/** Parse JSON from a Response. */
+async function parseJson(response: Response): Promise<unknown> {
+  return response.json();
+}
+
+/** Make a POST request to /api/open with a given body. */
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost:3000/api/open', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  // Default: exec succeeds immediately
+  mockExec.mockImplementation((_cmd: string, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
+    callback(null, '', '');
+  });
+
+  // Default: one known project at /home/testuser/repos/my-project
+  mockDiscoverProjects.mockResolvedValue([
+    {
+      name: 'my-project',
+      path: '/home/testuser/repos/my-project',
+      skills: [],
+    },
+  ]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('POST /api/open — input validation', () => {
+  it('returns 400 when body is missing filePath', async () => {
+    const req = makeRequest({});
+    const response = await POST(req);
+
+    expect(response.status).toBe(400);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 400 when filePath is not a string', async () => {
+    const req = makeRequest({ filePath: 42 });
+    const response = await POST(req);
+
+    expect(response.status).toBe(400);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 400 when filePath is empty string', async () => {
+    const req = makeRequest({ filePath: '' });
+    const response = await POST(req);
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when request body is malformed JSON', async () => {
+    const req = new Request('http://localhost:3000/api/open', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not-json',
+    });
+    const response = await POST(req);
+
+    expect(response.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path validation / security
+// ---------------------------------------------------------------------------
+
+describe('POST /api/open — path validation', () => {
+  it('returns 403 when filePath is outside all known paths', async () => {
+    mockDiscoverProjects.mockResolvedValue([
+      { name: 'my-project', path: '/home/testuser/repos/my-project', skills: [] },
+    ]);
+
+    const req = makeRequest({ filePath: '/etc/passwd' });
+    const response = await POST(req);
+
+    expect(response.status).toBe(403);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 403 for path traversal attempts', async () => {
+    const req = makeRequest({
+      filePath: '/home/testuser/repos/my-project/../../etc/passwd',
+    });
+    const response = await POST(req);
+
+    expect(response.status).toBe(403);
+  });
+
+  it('allows paths inside a known project directory', async () => {
+    mockDiscoverProjects.mockResolvedValue([
+      { name: 'my-project', path: '/home/testuser/repos/my-project', skills: [] },
+    ]);
+
+    const req = makeRequest({
+      filePath: '/home/testuser/repos/my-project/.claude/skills/my-skill.md',
+    });
+    const response = await POST(req);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('allows paths inside user-level ~/.claude directory', async () => {
+    mockDiscoverProjects.mockResolvedValue([]);
+
+    const req = makeRequest({
+      filePath: '/home/testuser/.claude/skills/my-skill.md',
+    });
+    const response = await POST(req);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('rejects paths that start-with match but are actually outside (prefix attack)', async () => {
+    mockDiscoverProjects.mockResolvedValue([
+      { name: 'my-project', path: '/home/testuser/repos/my-project', skills: [] },
+    ]);
+
+    // /home/testuser/repos/my-project-evil starts with /home/testuser/repos/my-project
+    // but is NOT inside it
+    const req = makeRequest({
+      filePath: '/home/testuser/repos/my-project-evil/secret.md',
+    });
+    const response = await POST(req);
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful open
+// ---------------------------------------------------------------------------
+
+describe('POST /api/open — successful open', () => {
+  it('returns 200 with success message on valid path', async () => {
+    const req = makeRequest({
+      filePath: '/home/testuser/repos/my-project/.claude/skills/my-skill.md',
+    });
+    const response = await POST(req);
+
+    expect(response.status).toBe(200);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('success', true);
+  });
+
+  it('calls exec with the file path', async () => {
+    const req = makeRequest({
+      filePath: '/home/testuser/repos/my-project/.claude/skills/my-skill.md',
+    });
+    await POST(req);
+
+    expect(mockExec).toHaveBeenCalledOnce();
+    const [cmd] = mockExec.mock.calls[0];
+    expect(cmd).toContain('/home/testuser/repos/my-project/.claude/skills/my-skill.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exec failure
+// ---------------------------------------------------------------------------
+
+describe('POST /api/open — exec failure', () => {
+  it('returns 500 when exec fails', async () => {
+    mockExec.mockImplementation((_cmd: string, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
+      callback(new Error('command failed'), '', '');
+    });
+
+    const req = makeRequest({
+      filePath: '/home/testuser/repos/my-project/.claude/skills/my-skill.md',
+    });
+    const response = await POST(req);
+
+    expect(response.status).toBe(500);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/src/app/api/open/route.ts
+++ b/src/app/api/open/route.ts
@@ -1,0 +1,169 @@
+/**
+ * POST /api/open
+ *
+ * Opens a skill file in the user's default application for .md files.
+ * Uses the appropriate OS command:
+ *   - Windows: start "" "<filePath>"
+ *   - macOS:   open "<filePath>"
+ *   - Linux:   xdg-open "<filePath>"
+ *
+ * Request body:
+ *   { filePath: string }
+ *
+ * Response (200):
+ *   { success: true }
+ *
+ * Response (400):
+ *   { error: string }  — missing or invalid filePath
+ *
+ * Response (403):
+ *   { error: string }  — filePath is outside allowed directories
+ *
+ * Response (500):
+ *   { error: string }  — OS command failed
+ *
+ * Security: filePath is validated to be within known project paths or
+ * the user-level ~/.claude directory. Path traversal is blocked by
+ * resolving to an absolute path before checking.
+ */
+
+import { exec } from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import { NextResponse } from 'next/server';
+import { discoverProjects } from '@/lib/scanner/discover';
+
+// ---------------------------------------------------------------------------
+// Path validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a path to forward slashes and resolve it to an absolute path.
+ * This blocks traversal attacks (../../etc/passwd).
+ */
+function resolveAndNormalize(filePath: string): string {
+  return path.resolve(filePath).replace(/\\/g, '/');
+}
+
+/**
+ * Check whether `filePath` is nested inside `allowedDir`.
+ * Uses a strict prefix match with a trailing slash to prevent
+ * prefix-only attacks (e.g. /home/user/repos/proj-evil when proj is allowed).
+ */
+function isInsideDir(filePath: string, allowedDir: string): boolean {
+  const resolvedFile = resolveAndNormalize(filePath);
+  const resolvedDir = resolveAndNormalize(allowedDir);
+  const dirWithSlash = resolvedDir.endsWith('/') ? resolvedDir : `${resolvedDir}/`;
+  return resolvedFile.startsWith(dirWithSlash);
+}
+
+/**
+ * Validate that filePath is inside one of the allowed locations:
+ *   1. Any discovered project directory
+ *   2. The user-level ~/.claude directory
+ *
+ * Returns true if allowed, false otherwise.
+ */
+async function validateFilePath(filePath: string): Promise<boolean> {
+  const homeDir = os.homedir().replace(/\\/g, '/');
+  const userClaudeDir = `${homeDir}/.claude`;
+
+  // Check user-level ~/.claude directory
+  if (isInsideDir(filePath, userClaudeDir)) {
+    return true;
+  }
+
+  // Check known project directories
+  const projects = await discoverProjects();
+  for (const project of projects) {
+    if (isInsideDir(filePath, project.path)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// OS command builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the shell command to open a file with the default application.
+ * The file path is quoted to handle spaces.
+ */
+function buildOpenCommand(filePath: string): string {
+  const platform = os.platform();
+  // Escape double quotes in the path to prevent command injection
+  const safePath = filePath.replace(/"/g, '\\"');
+
+  if (platform === 'win32') {
+    // start "" opens with default handler; empty title required when path has spaces
+    return `start "" "${safePath}"`;
+  } else if (platform === 'darwin') {
+    return `open "${safePath}"`;
+  } else {
+    return `xdg-open "${safePath}"`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request): Promise<NextResponse> {
+  // Parse request body
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  // Validate filePath field
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    !('filePath' in body) ||
+    typeof (body as Record<string, unknown>)['filePath'] !== 'string'
+  ) {
+    return NextResponse.json(
+      { error: 'filePath is required and must be a string' },
+      { status: 400 }
+    );
+  }
+
+  const filePath = ((body as Record<string, unknown>)['filePath'] as string).trim();
+
+  if (filePath.length === 0) {
+    return NextResponse.json({ error: 'filePath must not be empty' }, { status: 400 });
+  }
+
+  // Security: validate path is within allowed directories
+  const allowed = await validateFilePath(filePath);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'Access denied: filePath is outside allowed directories' },
+      { status: 403 }
+    );
+  }
+
+  // Build and execute the OS-appropriate open command
+  const command = buildOpenCommand(filePath);
+
+  return new Promise<NextResponse>((resolve) => {
+    exec(command, (error) => {
+      if (error) {
+        console.error('[skill-lens] /api/open exec error:', error.message);
+        resolve(
+          NextResponse.json(
+            { error: `Failed to open file: ${error.message}` },
+            { status: 500 }
+          )
+        );
+      } else {
+        resolve(NextResponse.json({ success: true }));
+      }
+    });
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ThemeProvider } from "next-themes";
+import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -26,8 +28,19 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+          <Toaster />
+        </ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,101 @@
-import { Button } from "@/components/ui/button";
+'use client';
+
+/**
+ * Home page — fetches scan results and renders the inventory table.
+ */
+
+import * as React from 'react';
+import { InventoryTable } from '@/components/inventory-table';
+import type { ScanResult } from '@/lib/types';
+import type { SkillFile } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all SkillFiles from a ScanResult into a single flat list. */
+function flattenSkills(result: ScanResult): SkillFile[] {
+  const projectSkills = result.projects.flatMap((p) => p.skills);
+  return [...projectSkills, ...result.userSkills, ...result.pluginSkills];
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
 
 export default function Home() {
+  const [skills, setSkills] = React.useState<SkillFile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [scannedAt, setScannedAt] = React.useState<string | null>(null);
+  const [scanDurationMs, setScanDurationMs] = React.useState<number | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    async function runScan() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch('/api/scan');
+        const data = (await response.json()) as ScanResult & {
+          scanDurationMs: number;
+          error?: string;
+        };
+
+        if (cancelled) return;
+
+        if (!response.ok) {
+          setError(data.error ?? 'Scan failed');
+          return;
+        }
+
+        setSkills(flattenSkills(data));
+        setScannedAt(data.scannedAt);
+        setScanDurationMs(data.scanDurationMs);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void runScan();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
-    <div className="flex flex-1 flex-col items-center justify-center min-h-screen bg-background px-4">
-      <main className="flex flex-col items-center gap-6 text-center max-w-lg">
-        <h1 className="text-4xl font-bold tracking-tight">Skill Lens</h1>
-        <p className="text-lg text-muted-foreground">
-          Visualize and analyze Claude Code skills across all your projects.
-        </p>
-        <p className="text-sm text-muted-foreground">
-          Skill inventory, overlap detection, and gap analysis — coming soon.
-        </p>
-        <Button disabled>Scan Projects</Button>
+    <div className="flex flex-col min-h-screen bg-background">
+      <header className="border-b border-border px-6 py-4">
+        <div className="max-w-7xl mx-auto flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold tracking-tight">Skill Lens</h1>
+            <p className="text-xs text-muted-foreground">
+              Claude Code skill inventory across all projects
+            </p>
+          </div>
+          {scannedAt && (
+            <p className="text-xs text-muted-foreground">
+              Scanned {new Date(scannedAt).toLocaleTimeString()} &middot;{' '}
+              {scanDurationMs}ms
+            </p>
+          )}
+        </div>
+      </header>
+
+      <main className="flex-1 px-6 py-6 max-w-7xl mx-auto w-full">
+        {error ? (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            <strong>Scan error:</strong> {error}
+          </div>
+        ) : (
+          <InventoryTable skills={skills} loading={loading} />
+        )}
       </main>
     </div>
   );

--- a/src/components/inventory-table.tsx
+++ b/src/components/inventory-table.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+/**
+ * InventoryTable — displays all discovered skill/agent/rule files.
+ *
+ * Features:
+ * - Columns: Name, Type, Level, Project, Description
+ * - Global search (filters name + description)
+ * - Sortable columns (click header to toggle)
+ * - "Open" button per row — calls POST /api/open and shows toast feedback
+ */
+
+import * as React from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import type { SkillFile } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SortKey = 'name' | 'type' | 'level' | 'projectName' | 'description';
+type SortDir = 'asc' | 'desc';
+
+interface InventoryTableProps {
+  /** All skill files to display (flat list across all projects and levels). */
+  skills: SkillFile[];
+  /** Whether the data is still loading. */
+  loading?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Open a file via the API and show a toast. */
+async function openFile(filePath: string): Promise<void> {
+  try {
+    const response = await fetch('/api/open', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ filePath }),
+    });
+
+    if (response.ok) {
+      toast.success('File opened in default editor');
+    } else {
+      const data = (await response.json()) as { error?: string };
+      toast.error(data.error ?? 'Failed to open file');
+    }
+  } catch {
+    toast.error('Network error — could not open file');
+  }
+}
+
+/** Case-insensitive string comparison for sorting. */
+function compareStrings(a: string | null, b: string | null): number {
+  const sa = (a ?? '').toLowerCase();
+  const sb = (b ?? '').toLowerCase();
+  if (sa < sb) return -1;
+  if (sa > sb) return 1;
+  return 0;
+}
+
+/** Sort a list of SkillFiles by the given key and direction. */
+function sortSkills(skills: SkillFile[], key: SortKey, dir: SortDir): SkillFile[] {
+  const sorted = [...skills].sort((a, b) => {
+    let cmp: number;
+    switch (key) {
+      case 'name':
+        cmp = compareStrings(a.name, b.name);
+        break;
+      case 'type':
+        cmp = compareStrings(a.type, b.type);
+        break;
+      case 'level':
+        cmp = compareStrings(a.level, b.level);
+        break;
+      case 'projectName':
+        cmp = compareStrings(a.projectName, b.projectName);
+        break;
+      case 'description':
+        cmp = compareStrings(a.description, b.description);
+        break;
+      default:
+        cmp = 0;
+    }
+    return dir === 'asc' ? cmp : -cmp;
+  });
+  return sorted;
+}
+
+/** Filter skills by a global search query (name + description). */
+function filterSkills(skills: SkillFile[], query: string): SkillFile[] {
+  if (!query.trim()) return skills;
+  const q = query.trim().toLowerCase();
+  return skills.filter(
+    (s) =>
+      s.name.toLowerCase().includes(q) ||
+      s.description.toLowerCase().includes(q)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Column header with sort indicator
+// ---------------------------------------------------------------------------
+
+interface SortableHeaderProps {
+  label: string;
+  sortKey: SortKey;
+  currentSort: SortKey;
+  currentDir: SortDir;
+  onSort: (key: SortKey) => void;
+}
+
+function SortableHeader({
+  label,
+  sortKey,
+  currentSort,
+  currentDir,
+  onSort,
+}: SortableHeaderProps) {
+  const isActive = currentSort === sortKey;
+  const indicator = isActive ? (currentDir === 'asc' ? ' ↑' : ' ↓') : '';
+
+  return (
+    <th
+      className="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider cursor-pointer select-none hover:text-foreground transition-colors"
+      onClick={() => onSort(sortKey)}
+    >
+      {label}
+      <span className="ml-0.5 opacity-70">{indicator}</span>
+    </th>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Badge for type / level
+// ---------------------------------------------------------------------------
+
+const TYPE_COLORS: Record<SkillFile['type'], string> = {
+  skill: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  agent: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+  rule: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+};
+
+const LEVEL_COLORS: Record<SkillFile['level'], string> = {
+  user: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  project: 'bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
+  plugin: 'bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-200',
+};
+
+function Badge({
+  label,
+  colorClass,
+}: {
+  label: string;
+  colorClass: string;
+}) {
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${colorClass}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function SkeletonRow() {
+  return (
+    <tr className="border-b border-border">
+      {[1, 2, 3, 4, 5, 6].map((i) => (
+        <td key={i} className="px-3 py-2">
+          <div className="h-4 bg-muted rounded animate-pulse" />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function InventoryTable({ skills, loading = false }: InventoryTableProps) {
+  const [searchQuery, setSearchQuery] = React.useState('');
+  const [sortKey, setSortKey] = React.useState<SortKey>('name');
+  const [sortDir, setSortDir] = React.useState<SortDir>('asc');
+  const [openingPath, setOpeningPath] = React.useState<string | null>(null);
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  const handleOpen = async (filePath: string) => {
+    setOpeningPath(filePath);
+    await openFile(filePath);
+    setOpeningPath(null);
+  };
+
+  const filtered = filterSkills(skills, searchQuery);
+  const sorted = sortSkills(filtered, sortKey, sortDir);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Search bar */}
+      <div className="flex items-center gap-2">
+        <input
+          type="search"
+          placeholder="Search by name or description…"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="flex-1 h-8 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        />
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {sorted.length} / {skills.length}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <SortableHeader
+                label="Name"
+                sortKey="name"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                label="Type"
+                sortKey="type"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                label="Level"
+                sortKey="level"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                label="Project"
+                sortKey="projectName"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                label="Description"
+                sortKey="description"
+                currentSort={sortKey}
+                currentDir={sortDir}
+                onSort={handleSort}
+              />
+              <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {loading ? (
+              Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+            ) : sorted.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-3 py-8 text-center text-sm text-muted-foreground"
+                >
+                  {skills.length === 0
+                    ? 'No skills found. Make sure your projects are scanned.'
+                    : 'No results match your search.'}
+                </td>
+              </tr>
+            ) : (
+              sorted.map((skill) => (
+                <tr
+                  key={skill.filePath}
+                  className="hover:bg-muted/30 transition-colors"
+                >
+                  <td className="px-3 py-2 font-medium max-w-[200px] truncate">
+                    {skill.name}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Badge
+                      label={skill.type}
+                      colorClass={TYPE_COLORS[skill.type]}
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <Badge
+                      label={skill.level}
+                      colorClass={LEVEL_COLORS[skill.level]}
+                    />
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground max-w-[160px] truncate">
+                    {skill.projectName ?? '—'}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground max-w-[300px] truncate">
+                    {skill.description || '—'}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      onClick={() => handleOpen(skill.filePath)}
+                      disabled={openingPath === skill.filePath}
+                      aria-label={`Open ${skill.name} in editor`}
+                    >
+                      {openingPath === skill.filePath ? 'Opening…' : 'Open'}
+                    </Button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
## Summary
Adds "Open in Editor" action to each skill file row — POST `/api/open` detects the OS and runs the appropriate command (`start` on Windows, `open` on macOS, `xdg-open` on Linux). Path validation prevents arbitrary file access. Also delivers the inventory table component (with sort, search, and Open button) and wires up toast feedback via Sonner.

## Changes
- `src/app/api/open/route.ts` — new POST endpoint with OS-aware file opening and path validation
- `src/app/api/open/route.test.ts` — integration tests (input validation, security, success, exec failure)
- `src/components/inventory-table.tsx` — inventory table with sortable columns, global search, Open button per row
- `src/components/ui/sonner.tsx` — Sonner Toaster component (installed via shadcn)
- `src/app/layout.tsx` — added ThemeProvider + Toaster
- `src/app/page.tsx` — wired up InventoryTable, fetches `/api/scan` on load
- `package.json` / `package-lock.json` — added `sonner` and `next-themes` dependencies

## Output Files
- `src/app/api/open/route.ts`
- `src/app/api/open/route.test.ts`
- `src/components/inventory-table.tsx`

## Testing
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 79 tests across 5 test files

## Acceptance Criteria
- [x] "Open" button on each table row
- [x] Opens file in default .md editor on Windows (`start "" "<path>"`)
- [x] Path validation prevents arbitrary file access (403 for out-of-bounds paths, traversal blocked by `path.resolve`)
- [x] Toast feedback on success/failure (sonner toasts)

Fixes #8

---
Generated with Claude Code
