### PR TITLE
feat: create overlaps page with cluster cards - fixes #12

### DIFF
--- a/src/app/api/analyze/route.test.ts
+++ b/src/app/api/analyze/route.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Integration tests for GET /api/analyze
+ *
+ * AC1: "API route returns OverlapCluster[] alongside ScanResult" → integration (API route handler)
+ * AC2: "Returns empty clusters array when no overlaps found" → integration
+ * AC3: "Clusters are sorted: drifted first, then by copy count descending" → integration
+ * AC4: "Returns HTTP 500 with error message when scan fails" → integration
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/scanner/discover', () => ({
+  discoverProjects: vi.fn(),
+}));
+
+vi.mock('@/lib/scanner/scan', () => ({
+  scanAll: vi.fn(),
+}));
+
+import { discoverProjects } from '@/lib/scanner/discover';
+import { scanAll } from '@/lib/scanner/scan';
+import { GET } from './route';
+import type { Project, ScanResult, SkillFile } from '@/lib/types';
+
+const mockDiscoverProjects = vi.mocked(discoverProjects);
+const mockScanAll = vi.mocked(scanAll);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _counter = 0;
+
+function makeSkillFile(overrides: Partial<SkillFile> & { filePath: string }): SkillFile {
+  _counter += 1;
+  return {
+    name: `Skill ${_counter}`,
+    description: '',
+    type: 'skill',
+    level: 'project',
+    projectName: `project-${_counter}`,
+    projectPath: `/repos/project-${_counter}`,
+    frontmatter: {},
+    body: 'body',
+    contentHash: `hash-${_counter}`,
+    ...overrides,
+  };
+}
+
+function makeScanResult(overrides: Partial<ScanResult> = {}): ScanResult {
+  return {
+    projects: [],
+    userSkills: [],
+    pluginSkills: [],
+    scannedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  return response.json();
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  _counter = 0;
+  mockDiscoverProjects.mockResolvedValue([]);
+  mockScanAll.mockResolvedValue(makeScanResult());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// AC1: Returns OverlapCluster[] alongside ScanResult
+// ---------------------------------------------------------------------------
+
+describe('GET /api/analyze — response shape', () => {
+  it('returns HTTP 200', async () => {
+    const req = new Request('http://localhost:3000/api/analyze');
+    const response = await GET(req);
+    expect(response.status).toBe(200);
+  });
+
+  it('response body contains clusters, projects, userSkills, pluginSkills, scannedAt, scanDurationMs', async () => {
+    const req = new Request('http://localhost:3000/api/analyze');
+    const response = await GET(req);
+    const body = await parseJson(response) as Record<string, unknown>;
+
+    expect(body).toHaveProperty('clusters');
+    expect(body).toHaveProperty('projects');
+    expect(body).toHaveProperty('userSkills');
+    expect(body).toHaveProperty('pluginSkills');
+    expect(body).toHaveProperty('scannedAt');
+    expect(body).toHaveProperty('scanDurationMs');
+    expect(Array.isArray(body['clusters'])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2: Returns empty clusters when no overlaps
+// ---------------------------------------------------------------------------
+
+describe('GET /api/analyze — empty clusters', () => {
+  it('returns empty clusters array when no files share a filename', async () => {
+    const project: Project = {
+      name: 'my-app',
+      path: '/repos/my-app',
+      skills: [
+        makeSkillFile({ filePath: '/repos/my-app/.claude/skills/save/SKILL.md' }),
+        makeSkillFile({ filePath: '/repos/my-app/.claude/rules/lint.md' }),
+      ],
+    };
+    mockDiscoverProjects.mockResolvedValue([project]);
+    mockScanAll.mockResolvedValue(makeScanResult({ projects: [project] }));
+
+    const req = new Request('http://localhost:3000/api/analyze');
+    const response = await GET(req);
+    const body = await parseJson(response) as Record<string, unknown>;
+
+    expect(body['clusters']).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3: Drifted clusters come first; tied status sorted by copy count desc
+// ---------------------------------------------------------------------------
+
+describe('GET /api/analyze — sort order', () => {
+  it('puts drifted clusters before identical clusters', async () => {
+    const sharedHash = 'same';
+    const project1: Project = {
+      name: 'project-a',
+      path: '/repos/project-a',
+      skills: [
+        makeSkillFile({
+          filePath: '/repos/project-a/.claude/skills/commit/SKILL.md',
+          contentHash: sharedHash,
+          projectName: 'project-a',
+        }),
+        makeSkillFile({
+          filePath: '/repos/project-a/.claude/rules/lint.md',
+          contentHash: 'hash-x',
+          projectName: 'project-a',
+        }),
+      ],
+    };
+    const project2: Project = {
+      name: 'project-b',
+      path: '/repos/project-b',
+      skills: [
+        makeSkillFile({
+          filePath: '/repos/project-b/.claude/skills/commit/SKILL.md',
+          contentHash: sharedHash,
+          projectName: 'project-b',
+        }),
+        makeSkillFile({
+          filePath: '/repos/project-b/.claude/rules/lint.md',
+          contentHash: 'hash-y', // different → drifted
+          projectName: 'project-b',
+        }),
+      ],
+    };
+    mockDiscoverProjects.mockResolvedValue([project1, project2]);
+    mockScanAll.mockResolvedValue(
+      makeScanResult({ projects: [project1, project2] })
+    );
+
+    const req = new Request('http://localhost:3000/api/analyze');
+    const response = await GET(req);
+    const body = await parseJson(response) as Record<string, unknown>;
+    const clusters = body['clusters'] as Array<{ filename: string; status: string }>;
+
+    expect(clusters.length).toBe(2);
+    // drifted (lint.md) must come before identical (SKILL.md)
+    expect(clusters[0].status).toBe('drifted');
+    expect(clusters[1].status).toBe('identical');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC4: Error handling
+// ---------------------------------------------------------------------------
+
+describe('GET /api/analyze — error handling', () => {
+  it('returns HTTP 500 when scan fails', async () => {
+    mockDiscoverProjects.mockRejectedValue(new Error('disk read failure'));
+
+    const req = new Request('http://localhost:3000/api/analyze');
+    const response = await GET(req);
+
+    expect(response.status).toBe(500);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('error');
+  });
+
+  it('error response includes scanDurationMs', async () => {
+    mockDiscoverProjects.mockRejectedValue(new Error('oops'));
+
+    const req = new Request('http://localhost:3000/api/analyze');
+    const response = await GET(req);
+    const body = await parseJson(response) as Record<string, unknown>;
+
+    expect(body).toHaveProperty('scanDurationMs');
+    expect(typeof body['scanDurationMs']).toBe('number');
+  });
+});

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -1,0 +1,85 @@
+/**
+ * GET /api/analyze
+ *
+ * Runs the full scan pipeline, then analyzes overlaps across all discovered
+ * skill files. Returns the ScanResult extended with overlap clusters and timing.
+ *
+ * Query params:
+ *   additionalPaths — comma-separated list of extra directories to scan
+ *
+ * Response (200):
+ *   ScanResult & { clusters: OverlapCluster[]; scanDurationMs: number }
+ *
+ * Response (500):
+ *   { error: string; scanDurationMs: number }
+ */
+
+import { NextResponse } from 'next/server';
+import { discoverProjects } from '@/lib/scanner/discover';
+import { scanAll } from '@/lib/scanner/scan';
+import { buildOverlapClusters } from '@/lib/analyzer/overlaps';
+import type { ScanResult, OverlapCluster, SkillFile } from '@/lib/types';
+
+export interface AnalyzeResponse extends ScanResult {
+  clusters: OverlapCluster[];
+  scanDurationMs: number;
+}
+
+export interface AnalyzeErrorResponse {
+  error: string;
+  scanDurationMs: number;
+}
+
+export async function GET(
+  request: Request
+): Promise<NextResponse<AnalyzeResponse | AnalyzeErrorResponse>> {
+  const startMs = Date.now();
+
+  const { searchParams } = new URL(request.url);
+  const additionalPathsParam = searchParams.get('additionalPaths') ?? '';
+  const additionalPaths = additionalPathsParam
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  try {
+    const projects = await discoverProjects();
+    const result = await scanAll(projects, additionalPaths);
+
+    // Flatten all skill files for overlap analysis
+    const allFiles: SkillFile[] = [
+      ...result.projects.flatMap((p) => p.skills),
+      ...result.userSkills,
+      ...result.pluginSkills,
+    ];
+
+    const rawClusters = buildOverlapClusters(allFiles);
+
+    // Sort: drifted first, then by number of copies descending
+    const clusters = [...rawClusters].sort((a, b) => {
+      if (a.status !== b.status) {
+        return a.status === 'drifted' ? -1 : 1;
+      }
+      return b.files.length - a.files.length;
+    });
+
+    const scanDurationMs = Date.now() - startMs;
+
+    return NextResponse.json<AnalyzeResponse>({
+      ...result,
+      clusters,
+      scanDurationMs,
+    });
+  } catch (err) {
+    const scanDurationMs = Date.now() - startMs;
+    const message =
+      err instanceof Error ? err.message : 'Unknown error during analysis';
+
+    console.error('[skill-lens] /api/analyze error:', message);
+
+    return NextResponse.json<AnalyzeErrorResponse>(
+      { error: message, scanDurationMs },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/overlaps/page.tsx
+++ b/src/app/overlaps/page.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardAction,
+  CardContent,
+} from "@/components/ui/card";
+import { DiffView } from "@/components/diff-view";
+import type { OverlapCluster, SkillFile } from "@/lib/types";
+import type { AnalyzeResponse, AnalyzeErrorResponse } from "@/app/api/analyze/route";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type FilterMode = "all" | "drifted" | "identical";
+
+type ScanState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ok"; clusters: OverlapCluster[]; scannedAt: string; durationMs: number };
+
+// ---------------------------------------------------------------------------
+// Badge helpers
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }: { status: OverlapCluster["status"] }) {
+  if (status === "drifted") {
+    return (
+      <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 ring-1 ring-inset ring-amber-600/20">
+        drifted
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 ring-1 ring-inset ring-green-600/20">
+      identical
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Location label for a single SkillFile
+// ---------------------------------------------------------------------------
+
+function locationLabel(skill: SkillFile): string {
+  if (skill.level === "user") return "~/.claude (user)";
+  if (skill.level === "plugin") return "plugin";
+  return skill.projectName ?? skill.filePath;
+}
+
+// ---------------------------------------------------------------------------
+// ClusterCard — one card per overlap cluster
+// ---------------------------------------------------------------------------
+
+interface ClusterCardProps {
+  cluster: OverlapCluster;
+  onOpenDiff: (cluster: OverlapCluster) => void;
+}
+
+function ClusterCard({ cluster, onOpenDiff }: ClusterCardProps) {
+  const isDrifted = cluster.status === "drifted";
+
+  return (
+    <Card
+      className={
+        isDrifted
+          ? "border border-amber-200 dark:border-amber-800/50"
+          : "border border-border"
+      }
+    >
+      <CardHeader className="border-b">
+        <CardTitle className="font-mono text-sm">{cluster.filename}</CardTitle>
+        <CardAction>
+          <StatusBadge status={cluster.status} />
+        </CardAction>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-3 pt-3">
+        {/* Copy count summary */}
+        <p className="text-xs text-muted-foreground">
+          {cluster.files.length} cop{cluster.files.length === 1 ? "y" : "ies"}
+          {isDrifted && (
+            <span className="ml-2 text-amber-700 dark:text-amber-400 font-medium">
+              — content has diverged across locations
+            </span>
+          )}
+        </p>
+
+        {/* Location list */}
+        <ul className="flex flex-col gap-1">
+          {cluster.files.map((file) => (
+            <li
+              key={file.filePath}
+              className="flex items-center gap-2 text-xs"
+              title={file.filePath}
+            >
+              {/* Level badge */}
+              <span
+                className={
+                  file.level === "user"
+                    ? "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 shrink-0"
+                    : file.level === "plugin"
+                      ? "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300 shrink-0"
+                      : "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300 shrink-0"
+                }
+              >
+                {file.level}
+              </span>
+              <span className="truncate text-muted-foreground font-mono">
+                {locationLabel(file)}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        {/* Diff button — only shown when there are 2+ files to compare */}
+        {cluster.files.length >= 2 && (
+          <div className="pt-1">
+            <button
+              onClick={() => onOpenDiff(cluster)}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted/60 transition-colors focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              View diff
+            </button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DiffModal — overlay showing DiffView for a selected cluster
+// ---------------------------------------------------------------------------
+
+interface DiffModalProps {
+  cluster: OverlapCluster;
+  onClose: () => void;
+}
+
+function DiffModal({ cluster, onClose }: DiffModalProps) {
+  // Close on Escape key
+  React.useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Diff view for ${cluster.filename}`}
+    >
+      <div className="relative flex flex-col w-full max-w-6xl h-[80vh] rounded-xl border border-border bg-card shadow-2xl overflow-hidden">
+        {/* Modal header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-sm font-semibold">
+              {cluster.filename}
+            </span>
+            <StatusBadge status={cluster.status} />
+            <span className="text-xs text-muted-foreground ml-1">
+              {cluster.files.length} cop{cluster.files.length === 1 ? "y" : "ies"}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground text-xl leading-none ml-4"
+            aria-label="Close diff view"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* DiffView fills remaining height */}
+        <div className="flex-1 min-h-0 p-4">
+          <DiffView files={cluster.files} onClose={onClose} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OverlapsPage — main page component
+// ---------------------------------------------------------------------------
+
+export default function OverlapsPage() {
+  const [scan, setScan] = React.useState<ScanState>({ status: "loading" });
+  const [filter, setFilter] = React.useState<FilterMode>("all");
+  const [activeDiff, setActiveDiff] = React.useState<OverlapCluster | null>(null);
+
+  React.useEffect(() => {
+    async function runAnalyze() {
+      try {
+        const res = await fetch("/api/analyze");
+        if (!res.ok) {
+          const errBody = (await res.json()) as AnalyzeErrorResponse;
+          setScan({ status: "error", message: errBody.error });
+          return;
+        }
+        const data = (await res.json()) as AnalyzeResponse;
+        setScan({
+          status: "ok",
+          clusters: data.clusters,
+          scannedAt: data.scannedAt,
+          durationMs: data.scanDurationMs,
+        });
+      } catch (err) {
+        setScan({
+          status: "error",
+          message: err instanceof Error ? err.message : "Unknown error",
+        });
+      }
+    }
+
+    void runAnalyze();
+  }, []);
+
+  // Derived: apply filter
+  const visibleClusters = React.useMemo(() => {
+    if (scan.status !== "ok") return [];
+    if (filter === "all") return scan.clusters;
+    return scan.clusters.filter((c) => c.status === filter);
+  }, [scan, filter]);
+
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      {/* Header */}
+      <header className="border-b border-border px-6 py-4 shrink-0">
+        <div className="max-w-7xl mx-auto flex items-baseline gap-3">
+          <h1 className="text-xl font-bold tracking-tight">Skill Lens</h1>
+          <span className="text-sm text-muted-foreground">
+            Overlap clusters
+          </span>
+          <nav className="ml-auto flex items-center gap-4 text-sm">
+            <Link
+              href="/"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Inventory
+            </Link>
+            <span className="text-foreground font-medium">Overlaps</span>
+          </nav>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 px-6 py-6">
+        <div className="max-w-7xl mx-auto flex flex-col gap-4">
+          {/* Loading state */}
+          {scan.status === "loading" && (
+            <div className="flex flex-col items-center justify-center gap-3 py-20 text-muted-foreground">
+              <div className="size-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              <p className="text-sm">Analyzing overlaps…</p>
+            </div>
+          )}
+
+          {/* Error state */}
+          {scan.status === "error" && (
+            <div className="rounded-xl border border-destructive/40 bg-destructive/5 px-5 py-4 text-sm text-destructive">
+              <strong>Analysis failed:</strong> {scan.message}
+            </div>
+          )}
+
+          {/* OK state */}
+          {scan.status === "ok" && (
+            <>
+              {/* Toolbar */}
+              <div className="flex items-center justify-between flex-wrap gap-3">
+                <div className="flex items-center gap-2">
+                  {/* Filter buttons */}
+                  {(["all", "drifted", "identical"] as FilterMode[]).map(
+                    (mode) => (
+                      <button
+                        key={mode}
+                        onClick={() => setFilter(mode)}
+                        className={
+                          filter === mode
+                            ? "inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium bg-foreground text-background transition-colors"
+                            : "inline-flex items-center rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted/60 transition-colors"
+                        }
+                      >
+                        {mode === "all"
+                          ? `All (${scan.clusters.length})`
+                          : mode === "drifted"
+                            ? `Drifted (${scan.clusters.filter((c) => c.status === "drifted").length})`
+                            : `Identical (${scan.clusters.filter((c) => c.status === "identical").length})`}
+                      </button>
+                    )
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Scanned in {scan.durationMs}ms &middot;{" "}
+                  {new Date(scan.scannedAt).toLocaleTimeString()}
+                </p>
+              </div>
+
+              {/* Empty state — no overlaps found at all */}
+              {scan.clusters.length === 0 && (
+                <div className="rounded-xl border border-border bg-muted/20 px-5 py-14 text-center text-sm text-muted-foreground">
+                  <p className="font-medium text-base mb-1">No overlaps found</p>
+                  <p>
+                    Skills that share a filename across two or more locations
+                    will appear here.
+                  </p>
+                </div>
+              )}
+
+              {/* Empty state — filter produced no results but clusters exist */}
+              {scan.clusters.length > 0 && visibleClusters.length === 0 && (
+                <div className="rounded-xl border border-border bg-muted/20 px-5 py-10 text-center text-sm text-muted-foreground">
+                  No {filter} clusters found.
+                </div>
+              )}
+
+              {/* Cluster grid */}
+              {visibleClusters.length > 0 && (
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {visibleClusters.map((cluster) => (
+                    <ClusterCard
+                      key={cluster.filename}
+                      cluster={cluster}
+                      onOpenDiff={setActiveDiff}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </main>
+
+      {/* Diff modal */}
+      {activeDiff !== null && (
+        <DiffModal
+          cluster={activeDiff}
+          onClose={() => setActiveDiff(null)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/analyze` route that runs the full scan pipeline, builds `OverlapCluster[]` (sorted drifted-first, then by copy count descending), and returns it alongside `ScanResult` with timing
- Adds `/overlaps` page with a responsive cluster card grid, status badges (drifted/identical), filter toolbar (all/drifted/identical with counts), and a diff modal that wraps the existing `DiffView` component
- Drifted clusters are visually distinct with an amber border and inline divergence label; empty states handled for both no-overlaps and filter-no-results cases

## Acceptance Criteria

- [x] Page lists all overlap clusters
- [x] Drifted clusters visually distinct from identical (amber border + badge)
- [x] Click through to diff view (View diff button opens DiffModal)
- [x] Filters work (all / drifted / identical toolbar)
- [x] Empty state when no overlaps found

## Test plan

- All 112 existing tests pass (`npm test`)
- TypeScript: `npx tsc --noEmit` — no errors
- Lint: `npm run lint` — no errors (uses `next/link` instead of bare `<a>`)
- `/api/analyze` integration tests cover response shape, empty clusters, drifted-first sort order, and HTTP 500 error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
