### PR TITLE
feat: add CLAUDE.md viewer for project context (#17)

### DIFF
--- a/src/app/api/claude-md/route.test.ts
+++ b/src/app/api/claude-md/route.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration tests for GET /api/claude-md
+ *
+ * AC1: "CLAUDE.md content displayed when viewing a project" → integration (API route handler)
+ * AC2: "Both user and project level shown if both exist" → integration (API route handler)
+ * AC3: "Returns 404 when no CLAUDE.md exists at either level" → integration (error response)
+ * AC4: "Returns 400 when projectPath param is missing" → integration (validation)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/user'),
+}));
+
+import * as fs from 'fs';
+import { GET } from './route';
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockExistsSync.mockReturnValue(false);
+  mockReadFileSync.mockReturnValue('');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRequest(params: Record<string, string>): Request {
+  const url = new URL('http://localhost:3000/api/claude-md');
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new Request(url.toString());
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  return response.json();
+}
+
+// ---------------------------------------------------------------------------
+// AC4: Input validation
+// ---------------------------------------------------------------------------
+
+describe('GET /api/claude-md — validation', () => {
+  it('returns 400 when projectPath param is missing', async () => {
+    const req = makeRequest({});
+    const response = await GET(req);
+    expect(response.status).toBe(400);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3: 404 when neither CLAUDE.md exists
+// ---------------------------------------------------------------------------
+
+describe('GET /api/claude-md — not found', () => {
+  it('returns 404 when neither user nor project CLAUDE.md exists', async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const req = makeRequest({ projectPath: '/repos/my-app' });
+    const response = await GET(req);
+    expect(response.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC1 + AC2: Content returned when files exist
+// ---------------------------------------------------------------------------
+
+describe('GET /api/claude-md — content', () => {
+  it('returns projectContent when project CLAUDE.md exists', async () => {
+    mockExistsSync.mockImplementation((p) => {
+      return String(p).includes('/repos/my-app/CLAUDE.md');
+    });
+    mockReadFileSync.mockImplementation((p) => {
+      if (String(p).includes('/repos/my-app/CLAUDE.md')) return '# Project Docs\nHello';
+      return '';
+    });
+
+    const req = makeRequest({ projectPath: '/repos/my-app' });
+    const response = await GET(req);
+    expect(response.status).toBe(200);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('projectContent', '# Project Docs\nHello');
+    expect(body).toHaveProperty('userContent', null);
+  });
+
+  it('returns userContent when user-level CLAUDE.md exists', async () => {
+    mockExistsSync.mockImplementation((p) => {
+      return String(p).includes('/home/user/.claude/CLAUDE.md');
+    });
+    mockReadFileSync.mockImplementation((p) => {
+      if (String(p).includes('/home/user/.claude/CLAUDE.md')) return '# Global Rules';
+      return '';
+    });
+
+    const req = makeRequest({ projectPath: '/repos/my-app' });
+    const response = await GET(req);
+    expect(response.status).toBe(200);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('userContent', '# Global Rules');
+    expect(body).toHaveProperty('projectContent', null);
+  });
+
+  it('returns both userContent and projectContent when both exist', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation((p) => {
+      if (String(p).includes('/repos/my-app/CLAUDE.md')) return '# Project';
+      if (String(p).includes('/home/user/.claude/CLAUDE.md')) return '# User';
+      return '';
+    });
+
+    const req = makeRequest({ projectPath: '/repos/my-app' });
+    const response = await GET(req);
+    expect(response.status).toBe(200);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('projectContent', '# Project');
+    expect(body).toHaveProperty('userContent', '# User');
+  });
+
+  it('response includes projectPath and userClaudeMdPath fields', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('# Content');
+
+    const req = makeRequest({ projectPath: '/repos/my-app' });
+    const response = await GET(req);
+    const body = await parseJson(response) as Record<string, unknown>;
+    expect(body).toHaveProperty('projectClaudeMdPath');
+    expect(body).toHaveProperty('userClaudeMdPath');
+  });
+});

--- a/src/app/api/claude-md/route.ts
+++ b/src/app/api/claude-md/route.ts
@@ -1,0 +1,94 @@
+/**
+ * GET /api/claude-md
+ *
+ * Returns the content of CLAUDE.md files for a given project path.
+ * Reads both user-level (~/.claude/CLAUDE.md) and project-level
+ * (<projectPath>/CLAUDE.md) if they exist.
+ *
+ * Query params:
+ *   projectPath — absolute path to the project root directory (required)
+ *
+ * Response (200):
+ *   {
+ *     projectContent: string | null;       // project-level CLAUDE.md content
+ *     userContent: string | null;          // user-level CLAUDE.md content
+ *     projectClaudeMdPath: string;         // absolute path (may not exist)
+ *     userClaudeMdPath: string;            // absolute path (may not exist)
+ *   }
+ *
+ * Response (400): { error: string } — missing required param
+ * Response (404): { error: string } — neither file exists
+ * Response (500): { error: string } — unexpected read error
+ */
+
+import { NextResponse } from 'next/server';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface ClaudeMdResponse {
+  projectContent: string | null;
+  userContent: string | null;
+  projectClaudeMdPath: string;
+  userClaudeMdPath: string;
+}
+
+export interface ClaudeMdErrorResponse {
+  error: string;
+}
+
+/**
+ * Safely read a file, returning null if it doesn't exist or cannot be read.
+ */
+function safeRead(filePath: string): string | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return fs.readFileSync(filePath, 'utf-8') as string;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(
+  request: Request
+): Promise<NextResponse<ClaudeMdResponse | ClaudeMdErrorResponse>> {
+  const { searchParams } = new URL(request.url);
+  const projectPath = searchParams.get('projectPath');
+
+  if (!projectPath) {
+    return NextResponse.json<ClaudeMdErrorResponse>(
+      { error: 'projectPath query parameter is required' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const homeDir = os.homedir().replace(/\\/g, '/');
+    const userClaudeMdPath = path.join(homeDir, '.claude', 'CLAUDE.md').replace(/\\/g, '/');
+    const projectClaudeMdPath = path.join(projectPath, 'CLAUDE.md').replace(/\\/g, '/');
+
+    const userContent = safeRead(userClaudeMdPath);
+    const projectContent = safeRead(projectClaudeMdPath);
+
+    if (userContent === null && projectContent === null) {
+      return NextResponse.json<ClaudeMdErrorResponse>(
+        { error: 'No CLAUDE.md found at user or project level' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json<ClaudeMdResponse>({
+      projectContent,
+      userContent,
+      projectClaudeMdPath,
+      userClaudeMdPath,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[skill-lens] /api/claude-md error:', message);
+    return NextResponse.json<ClaudeMdErrorResponse>(
+      { error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,14 +3,21 @@
 import * as React from "react";
 import { InventoryTable } from "@/components/inventory-table";
 import { ProjectSidebar } from "@/components/project-sidebar";
+import { ClaudeMdViewer } from "@/components/claude-md-viewer";
 import type { ProjectFilter } from "@/components/project-sidebar";
 import type { SkillFile } from "@/lib/types";
 import type { ScanResponse, ScanErrorResponse } from "@/app/api/scan/route";
 
+/** Minimal project info needed to look up paths for the CLAUDE.md viewer. */
+interface ProjectRef {
+  name: string;
+  path: string;
+}
+
 type ScanState =
   | { status: "loading" }
   | { status: "error"; message: string }
-  | { status: "ok"; skills: SkillFile[]; scannedAt: string; durationMs: number };
+  | { status: "ok"; skills: SkillFile[]; projects: ProjectRef[]; scannedAt: string; durationMs: number };
 
 export default function Home() {
   const [scan, setScan] = React.useState<ScanState>({ status: "loading" });
@@ -35,6 +42,7 @@ export default function Home() {
         setScan({
           status: "ok",
           skills: allSkills,
+          projects: data.projects.map((p) => ({ name: p.name, path: p.path })),
           scannedAt: data.scannedAt,
           durationMs: data.scanDurationMs,
         });
@@ -106,11 +114,25 @@ export default function Home() {
                     activeFilter={projectFilter}
                     onFilterChange={setProjectFilter}
                   />
-                  <div className="flex-1 min-w-0">
+                  <div className="flex-1 min-w-0 flex flex-col gap-4">
                     <InventoryTable
                       skills={scan.skills}
                       projectFilter={projectFilter}
                     />
+                    {/* CLAUDE.md viewer — shown when a specific project is selected */}
+                    {projectFilter !== null &&
+                      projectFilter !== "__user__" &&
+                      projectFilter !== "__plugin__" && (() => {
+                        const proj = scan.projects.find(
+                          (p) => p.name === projectFilter
+                        );
+                        return (
+                          <ClaudeMdViewer
+                            projectPath={proj?.path ?? null}
+                            projectName={proj?.name ?? projectFilter}
+                          />
+                        );
+                      })()}
                   </div>
                 </div>
               )}

--- a/src/components/claude-md-viewer.tsx
+++ b/src/components/claude-md-viewer.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
+import { ExternalLinkIcon, FileTextIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ClaudeMdResponse } from "@/app/api/claude-md/route";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ClaudeMdViewerProps {
+  /** Absolute path to the project root. Pass null to hide the viewer. */
+  projectPath: string | null;
+  /** Human-readable project name, used in headings. */
+  projectName: string | null;
+}
+
+type LoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ok"; data: ClaudeMdResponse };
+
+// ---------------------------------------------------------------------------
+// Tab type
+// ---------------------------------------------------------------------------
+
+type TabKey = "project" | "user";
+
+// ---------------------------------------------------------------------------
+// Open in Editor button
+// ---------------------------------------------------------------------------
+
+function OpenInEditorButton({ filePath }: { filePath: string }) {
+  const [status, setStatus] = React.useState<"idle" | "loading" | "error">(
+    "idle"
+  );
+
+  async function handleOpen() {
+    setStatus("loading");
+    try {
+      const res = await fetch("/api/open", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filePath }),
+      });
+      setStatus(res.ok ? "idle" : "error");
+      if (!res.ok) setTimeout(() => setStatus("idle"), 3000);
+    } catch {
+      setStatus("error");
+      setTimeout(() => setStatus("idle"), 3000);
+    }
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleOpen}
+      disabled={status === "loading"}
+      title={`Open ${filePath} in default editor`}
+    >
+      <ExternalLinkIcon className="size-3.5" />
+      {status === "error" ? "Failed to open" : "Open in Editor"}
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Markdown panel
+// ---------------------------------------------------------------------------
+
+function MarkdownPanel({
+  content,
+  filePath,
+}: {
+  content: string;
+  filePath: string;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      {/* File path + open button */}
+      <div className="flex items-center justify-between gap-3 rounded-lg bg-muted/50 px-3 py-2">
+        <span
+          className="flex-1 truncate font-mono text-xs text-muted-foreground"
+          title={filePath}
+        >
+          {filePath}
+        </span>
+        <OpenInEditorButton filePath={filePath} />
+      </div>
+
+      {/* Rendered markdown */}
+      <div className="prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_code:not(pre_code)]:rounded [&_code:not(pre_code)]:bg-muted [&_code:not(pre_code)]:px-1 [&_code:not(pre_code)]:py-0.5 [&_code:not(pre_code)]:text-xs">
+        <ReactMarkdown>{content}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab bar
+// ---------------------------------------------------------------------------
+
+interface TabBarProps {
+  activeTab: TabKey;
+  hasProject: boolean;
+  hasUser: boolean;
+  onTabChange: (tab: TabKey) => void;
+}
+
+function TabBar({ activeTab, hasProject, hasUser, onTabChange }: TabBarProps) {
+  return (
+    <div className="flex gap-1 border-b border-border pb-0">
+      {hasProject && (
+        <button
+          type="button"
+          onClick={() => onTabChange("project")}
+          className={[
+            "px-3 py-1.5 text-sm font-medium transition-colors border-b-2 -mb-px",
+            activeTab === "project"
+              ? "border-foreground text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground",
+          ].join(" ")}
+        >
+          Project
+        </button>
+      )}
+      {hasUser && (
+        <button
+          type="button"
+          onClick={() => onTabChange("user")}
+          className={[
+            "px-3 py-1.5 text-sm font-medium transition-colors border-b-2 -mb-px",
+            activeTab === "user"
+              ? "border-foreground text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground",
+          ].join(" ")}
+        >
+          User Level
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function ClaudeMdViewer({ projectPath, projectName }: ClaudeMdViewerProps) {
+  const [loadState, setLoadState] = React.useState<LoadState>({ status: "idle" });
+  const [activeTab, setActiveTab] = React.useState<TabKey>("project");
+
+  // Fetch when projectPath changes
+  React.useEffect(() => {
+    if (!projectPath) {
+      setLoadState({ status: "idle" });
+      return;
+    }
+
+    setLoadState({ status: "loading" });
+
+    const encoded = encodeURIComponent(projectPath);
+
+    fetch(`/api/claude-md?projectPath=${encoded}`)
+      .then(async (res) => {
+        if (res.status === 404) {
+          setLoadState({
+            status: "error",
+            message: "No CLAUDE.md found for this project.",
+          });
+          return;
+        }
+        if (!res.ok) {
+          const body = (await res.json()) as { error?: string };
+          setLoadState({
+            status: "error",
+            message: body.error ?? "Failed to load CLAUDE.md",
+          });
+          return;
+        }
+        const data = (await res.json()) as ClaudeMdResponse;
+        setLoadState({ status: "ok", data });
+        // Default to project tab if it has content, otherwise user
+        setActiveTab(data.projectContent !== null ? "project" : "user");
+      })
+      .catch((err: unknown) => {
+        setLoadState({
+          status: "error",
+          message: err instanceof Error ? err.message : "Unknown error",
+        });
+      });
+  }, [projectPath]);
+
+  if (!projectPath) return null;
+
+  return (
+    <div className="rounded-xl border border-border bg-card">
+      {/* Section header */}
+      <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+        <FileTextIcon className="size-4 text-muted-foreground shrink-0" />
+        <h2 className="text-sm font-semibold">
+          CLAUDE.md
+          {projectName && (
+            <span className="ml-1.5 font-normal text-muted-foreground">
+              — {projectName}
+            </span>
+          )}
+        </h2>
+      </div>
+
+      {/* Body */}
+      <div className="px-4 py-4">
+        {loadState.status === "loading" && (
+          <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+            <div className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            <span>Loading CLAUDE.md…</span>
+          </div>
+        )}
+
+        {loadState.status === "error" && (
+          <p className="py-4 text-sm text-muted-foreground italic">
+            {loadState.message}
+          </p>
+        )}
+
+        {loadState.status === "ok" && (() => {
+          const { projectContent, userContent, projectClaudeMdPath, userClaudeMdPath } = loadState.data;
+          const bothExist = projectContent !== null && userContent !== null;
+
+          // Determine which content to show in the panel
+          let panelContent: string;
+          let panelPath: string;
+          if (bothExist) {
+            panelContent = activeTab === "project"
+              ? projectContent
+              : (userContent ?? "");
+            panelPath = activeTab === "project"
+              ? projectClaudeMdPath
+              : userClaudeMdPath;
+          } else if (projectContent !== null) {
+            panelContent = projectContent;
+            panelPath = projectClaudeMdPath;
+          } else {
+            panelContent = userContent ?? "";
+            panelPath = userClaudeMdPath;
+          }
+
+          return (
+            <div className="flex flex-col gap-4">
+              {/* Tabs — only shown when both levels exist */}
+              {bothExist && (
+                <TabBar
+                  activeTab={activeTab}
+                  hasProject
+                  hasUser
+                  onTabChange={setActiveTab}
+                />
+              )}
+              <MarkdownPanel content={panelContent} filePath={panelPath} />
+            </div>
+          );
+        })()}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a CLAUDE.md viewer that displays rendered markdown content for both user-level (`~/.claude/CLAUDE.md`) and project-level (`<project>/CLAUDE.md`) instruction files when a project is selected in the sidebar.

## Changes

- `src/app/api/claude-md/route.ts` — new `GET /api/claude-md?projectPath=...` route that reads both CLAUDE.md files and returns their content (null if absent); returns 404 when neither exists
- `src/app/api/claude-md/route.test.ts` — integration tests for the new route (validation, 404, single-level, dual-level cases)
- `src/components/claude-md-viewer.tsx` — new `ClaudeMdViewer` component with tab switching (when both levels exist), rendered markdown via `react-markdown`, and "Open in Editor" button per file
- `src/app/page.tsx` — wires in the viewer below the inventory table when a specific project is selected; passes project path from scan response

## Output Files

- `src/app/api/claude-md/route.ts` (new)
- `src/app/api/claude-md/route.test.ts` (new)
- `src/components/claude-md-viewer.tsx` (new)
- `src/app/page.tsx` (modified)

## Testing

- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test` — 172 tests, 12 files)

## Acceptance Criteria

- [x] CLAUDE.md content displayed when viewing a project
- [x] Both user and project level shown if both exist (tab switching)
- [x] Rendered as HTML (not raw markdown) — via `react-markdown`
- [x] Open in Editor button — per file path, calls `/api/open`

Fixes #17

---
Generated with Claude Code
