### PR TITLE
feat: add additional scan paths via UI - fixes #18

### DIFF
--- a/src/app/api/validate-path/route.ts
+++ b/src/app/api/validate-path/route.ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/validate-path
+ *
+ * Checks whether a directory path exists on disk.
+ *
+ * Request body: { path: string }
+ *
+ * Response (200): { valid: true; resolvedPath: string }
+ * Response (200): { valid: false; reason: string }
+ * Response (400): { error: string }  — missing/invalid body
+ */
+
+import { NextResponse } from 'next/server';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+export interface ValidatePathSuccess {
+  valid: true;
+  resolvedPath: string;
+}
+
+export interface ValidatePathFailure {
+  valid: false;
+  reason: string;
+}
+
+export type ValidatePathResponse = ValidatePathSuccess | ValidatePathFailure;
+
+export interface ValidatePathErrorResponse {
+  error: string;
+}
+
+export async function POST(
+  request: Request
+): Promise<NextResponse<ValidatePathResponse | ValidatePathErrorResponse>> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return NextResponse.json({ error: 'Body must be an object' }, { status: 400 });
+  }
+
+  const { path: dirPath } = body as Record<string, unknown>;
+
+  if (!dirPath) {
+    return NextResponse.json({ error: 'path is required' }, { status: 400 });
+  }
+
+  if (typeof dirPath !== 'string') {
+    return NextResponse.json({ error: 'path must be a string' }, { status: 400 });
+  }
+
+  const trimmed = dirPath.trim();
+  if (trimmed.length === 0) {
+    return NextResponse.json({ error: 'path must not be empty' }, { status: 400 });
+  }
+
+  // Resolve to an absolute path (handles ~, relative paths, etc.)
+  const resolvedPath = path.resolve(
+    trimmed.replace(/^~/, process.env.HOME ?? process.env.USERPROFILE ?? '')
+  );
+
+  try {
+    const stat = await fs.stat(resolvedPath);
+    if (!stat.isDirectory()) {
+      return NextResponse.json<ValidatePathFailure>({
+        valid: false,
+        reason: 'Path exists but is not a directory',
+      });
+    }
+    return NextResponse.json<ValidatePathSuccess>({
+      valid: true,
+      resolvedPath: resolvedPath.replace(/\\/g, '/'),
+    });
+  } catch {
+    return NextResponse.json<ValidatePathFailure>({
+      valid: false,
+      reason: 'Directory does not exist or is not accessible',
+    });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import { InventoryTable } from "@/components/inventory-table";
 import { ProjectSidebar } from "@/components/project-sidebar";
 import { ClaudeMdViewer } from "@/components/claude-md-viewer";
+import { SettingsPanel, loadAdditionalPaths } from "@/components/settings-panel";
+import { Button } from "@/components/ui/button";
 import type { ProjectFilter } from "@/components/project-sidebar";
 import type { SkillFile } from "@/lib/types";
 import type { ScanResponse, ScanErrorResponse } from "@/app/api/scan/route";
@@ -22,52 +24,85 @@ type ScanState =
 export default function Home() {
   const [scan, setScan] = React.useState<ScanState>({ status: "loading" });
   const [projectFilter, setProjectFilter] = React.useState<ProjectFilter>(null);
+  const [additionalPaths, setAdditionalPaths] = React.useState<string[]>([]);
+  const [settingsOpen, setSettingsOpen] = React.useState(false);
 
+  // Load additional paths from localStorage on mount
   React.useEffect(() => {
-    async function runScan() {
-      try {
-        const res = await fetch("/api/scan");
-        if (!res.ok) {
-          const errBody = (await res.json()) as ScanErrorResponse;
-          setScan({ status: "error", message: errBody.error });
-          return;
-        }
-        const data = (await res.json()) as ScanResponse;
-        // Flatten all skills from all levels
-        const allSkills: SkillFile[] = [
-          ...data.projects.flatMap((p) => p.skills),
-          ...data.userSkills,
-          ...data.pluginSkills,
-        ];
-        setScan({
-          status: "ok",
-          skills: allSkills,
-          projects: data.projects.map((p) => ({ name: p.name, path: p.path })),
-          scannedAt: data.scannedAt,
-          durationMs: data.scanDurationMs,
-        });
-      } catch (err) {
-        setScan({
-          status: "error",
-          message: err instanceof Error ? err.message : "Unknown error",
-        });
-      }
-    }
-
-    void runScan();
+    setAdditionalPaths(loadAdditionalPaths());
   }, []);
+
+  const runScan = React.useCallback(async (paths: string[]) => {
+    setScan({ status: "loading" });
+    try {
+      const url =
+        paths.length > 0
+          ? `/api/scan?additionalPaths=${encodeURIComponent(paths.join(","))}`
+          : "/api/scan";
+      const res = await fetch(url);
+      if (!res.ok) {
+        const errBody = (await res.json()) as ScanErrorResponse;
+        setScan({ status: "error", message: errBody.error });
+        return;
+      }
+      const data = (await res.json()) as ScanResponse;
+      // Flatten all skills from all levels
+      const allSkills: SkillFile[] = [
+        ...data.projects.flatMap((p) => p.skills),
+        ...data.userSkills,
+        ...data.pluginSkills,
+      ];
+      setScan({
+        status: "ok",
+        skills: allSkills,
+        projects: data.projects.map((p) => ({ name: p.name, path: p.path })),
+        scannedAt: data.scannedAt,
+        durationMs: data.scanDurationMs,
+      });
+    } catch (err) {
+      setScan({
+        status: "error",
+        message: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  }, []);
+
+  // Run scan on mount and whenever additionalPaths changes
+  React.useEffect(() => {
+    void runScan(additionalPaths);
+  }, [additionalPaths, runScan]);
+
+  function handlePathsChange(paths: string[]) {
+    setAdditionalPaths(paths);
+  }
 
   return (
     <div className="flex flex-col min-h-screen bg-background">
       {/* Header */}
       <header className="border-b border-border px-6 py-4 shrink-0">
-        <div className="max-w-7xl mx-auto flex items-baseline gap-3">
-          <h1 className="text-xl font-bold tracking-tight">Skill Lens</h1>
-          <span className="text-sm text-muted-foreground">
-            Claude Code skill inventory
-          </span>
+        <div className="max-w-7xl mx-auto flex items-center justify-between gap-3">
+          <div className="flex items-baseline gap-3">
+            <h1 className="text-xl font-bold tracking-tight">Skill Lens</h1>
+            <span className="text-sm text-muted-foreground">
+              Claude Code skill inventory
+            </span>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setSettingsOpen(true)}
+          >
+            Settings
+          </Button>
         </div>
       </header>
+
+      {/* Settings panel */}
+      <SettingsPanel
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        onPathsChange={handlePathsChange}
+      />
 
       {/* Main content */}
       <main className="flex-1 px-6 py-6">

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import * as React from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import type {
+  ValidatePathResponse,
+  ValidatePathErrorResponse,
+} from "@/app/api/validate-path/route";
+
+// ---------------------------------------------------------------------------
+// Storage helpers
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = "skill-lens:additionalPaths";
+
+export function loadAdditionalPaths(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((p): p is string => typeof p === "string");
+  } catch {
+    return [];
+  }
+}
+
+function saveAdditionalPaths(paths: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(paths));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SettingsPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after any add/remove — lets the parent re-scan. */
+  onPathsChange: (paths: string[]) => void;
+}
+
+type ValidationState =
+  | { status: "idle" }
+  | { status: "validating" }
+  | { status: "error"; message: string }
+  | { status: "ok"; resolvedPath: string };
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function SettingsPanel({
+  open,
+  onOpenChange,
+  onPathsChange,
+}: SettingsPanelProps) {
+  const [paths, setPaths] = React.useState<string[]>([]);
+  const [input, setInput] = React.useState("");
+  const [validation, setValidation] = React.useState<ValidationState>({
+    status: "idle",
+  });
+
+  // Load from localStorage when the panel first opens
+  React.useEffect(() => {
+    if (open) {
+      setPaths(loadAdditionalPaths());
+      setInput("");
+      setValidation({ status: "idle" });
+    }
+  }, [open]);
+
+  async function handleAdd() {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+
+    // Avoid duplicates
+    if (paths.includes(trimmed)) {
+      setValidation({ status: "error", message: "Path already added" });
+      return;
+    }
+
+    setValidation({ status: "validating" });
+
+    try {
+      const res = await fetch("/api/validate-path", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: trimmed }),
+      });
+
+      if (!res.ok) {
+        const body = (await res.json()) as ValidatePathErrorResponse;
+        setValidation({ status: "error", message: body.error });
+        return;
+      }
+
+      const body = (await res.json()) as ValidatePathResponse;
+
+      if (!body.valid) {
+        setValidation({ status: "error", message: body.reason });
+        return;
+      }
+
+      // Use the server-resolved canonical path
+      const resolved = body.resolvedPath;
+      const next = paths.includes(resolved) ? paths : [...paths, resolved];
+      setPaths(next);
+      saveAdditionalPaths(next);
+      onPathsChange(next);
+      setInput("");
+      setValidation({ status: "ok", resolvedPath: resolved });
+    } catch (err) {
+      setValidation({
+        status: "error",
+        message: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  }
+
+  function handleRemove(p: string) {
+    const next = paths.filter((x) => x !== p);
+    setPaths(next);
+    saveAdditionalPaths(next);
+    onPathsChange(next);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      void handleAdd();
+    }
+  }
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setInput(e.target.value);
+    if (validation.status !== "idle") {
+      setValidation({ status: "idle" });
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-md flex flex-col">
+        <SheetHeader>
+          <SheetTitle>Scan Paths</SheetTitle>
+        </SheetHeader>
+
+        <div className="flex flex-col gap-6 mt-4 flex-1 overflow-y-auto">
+          {/* Add path section */}
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Add a directory path</label>
+            <p className="text-xs text-muted-foreground">
+              Additional directories to scan for skill files. Paths are
+              validated on the server and persisted in your browser.
+            </p>
+
+            <div className="flex gap-2 mt-1">
+              <input
+                type="text"
+                placeholder="/home/you/projects/my-repo"
+                value={input}
+                onChange={handleInputChange}
+                onKeyDown={handleKeyDown}
+                disabled={validation.status === "validating"}
+                className="flex-1 h-9 rounded-md border border-border bg-background px-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+              />
+              <Button
+                size="sm"
+                onClick={() => void handleAdd()}
+                disabled={
+                  !input.trim() || validation.status === "validating"
+                }
+              >
+                {validation.status === "validating" ? "Checking…" : "Add"}
+              </Button>
+            </div>
+
+            {/* Validation feedback */}
+            {validation.status === "error" && (
+              <p className="text-xs text-destructive mt-1">
+                {validation.message}
+              </p>
+            )}
+            {validation.status === "ok" && (
+              <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                Added: {validation.resolvedPath}
+              </p>
+            )}
+          </div>
+
+          {/* Saved paths list */}
+          <div className="flex flex-col gap-2">
+            <h3 className="text-sm font-medium">
+              Saved paths{" "}
+              <span className="text-muted-foreground font-normal">
+                ({paths.length})
+              </span>
+            </h3>
+
+            {paths.length === 0 ? (
+              <p className="text-xs text-muted-foreground py-4 text-center border border-dashed border-border rounded-lg">
+                No additional paths configured
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {paths.map((p) => (
+                  <li
+                    key={p}
+                    className="flex items-center justify-between gap-2 rounded-lg border border-border bg-muted/20 px-3 py-2"
+                  >
+                    <span
+                      className="text-xs font-mono text-foreground/80 break-all flex-1"
+                      title={p}
+                    >
+                      {p}
+                    </span>
+                    <button
+                      onClick={() => handleRemove(p)}
+                      className="shrink-0 text-xs text-muted-foreground hover:text-destructive transition-colors px-1"
+                      aria-label={`Remove ${p}`}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <p className="text-xs text-muted-foreground mt-auto">
+            Changes take effect immediately — the skill list will re-scan
+            automatically.
+          </p>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a Settings panel (slide-out sheet) for managing additional scan paths
- New `POST /api/validate-path` endpoint validates that a directory exists on disk before saving
- Paths are persisted in `localStorage` and passed as `additionalPaths` query param to `/api/scan`
- Scan re-runs automatically whenever paths are added or removed

## Changes
- **`src/app/api/validate-path/route.ts`** (new) -- POST endpoint that checks if a path is a valid directory, returns the resolved canonical path
- **`src/components/settings-panel.tsx`** (new) -- Sheet-based UI with text input, server-side validation, saved paths list with remove buttons
- **`src/app/page.tsx`** (updated) -- Reads additional paths from localStorage on mount, passes them to scan API, adds Settings button in header, re-scans on path changes

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (172 tests)
- [ ] Manual: open app, click Settings, add a valid directory path -- should appear in list and trigger re-scan
- [ ] Manual: add an invalid path -- should show error message, not be saved
- [ ] Manual: remove a path -- should disappear and trigger re-scan
- [ ] Manual: refresh page -- saved paths should persist and be included in scan

Fixes #18
