### PR TITLE
feat: add app navigation and layout shell (#19)

### DIFF
--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import Link from "next/link";
 import {
   Card,
   CardHeader,
@@ -356,30 +355,7 @@ export default function InsightsPage() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b border-border px-6 py-4 shrink-0">
-        <div className="max-w-7xl mx-auto flex items-baseline gap-3">
-          <h1 className="text-xl font-bold tracking-tight">Skill Lens</h1>
-          <span className="text-sm text-muted-foreground">Insights</span>
-          <nav className="ml-auto flex items-center gap-4 text-sm">
-            <Link
-              href="/"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Inventory
-            </Link>
-            <Link
-              href="/overlaps"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Overlaps
-            </Link>
-            <span className="text-foreground font-medium">Insights</span>
-          </nav>
-        </div>
-      </header>
-
+    <div className="flex flex-col min-h-[calc(100vh-3.5rem)] bg-background">
       {/* Main content */}
       <main className="flex-1 px-6 py-6">
         <div className="max-w-7xl mx-auto flex flex-col gap-8">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { NavBar } from "@/components/nav-bar";
+import { ScanProvider } from "@/components/scan-context";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +29,12 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <ScanProvider>
+          <NavBar />
+          {children}
+        </ScanProvider>
+      </body>
     </html>
   );
 }

--- a/src/app/overlaps/page.tsx
+++ b/src/app/overlaps/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import Link from "next/link";
 import {
   Card,
   CardHeader,
@@ -234,26 +233,7 @@ export default function OverlapsPage() {
   }, [scan, filter]);
 
   return (
-    <div className="flex flex-col min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b border-border px-6 py-4 shrink-0">
-        <div className="max-w-7xl mx-auto flex items-baseline gap-3">
-          <h1 className="text-xl font-bold tracking-tight">Skill Lens</h1>
-          <span className="text-sm text-muted-foreground">
-            Overlap clusters
-          </span>
-          <nav className="ml-auto flex items-center gap-4 text-sm">
-            <Link
-              href="/"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Inventory
-            </Link>
-            <span className="text-foreground font-medium">Overlaps</span>
-          </nav>
-        </div>
-      </header>
-
+    <div className="flex flex-col min-h-[calc(100vh-3.5rem)] bg-background">
       {/* Main content */}
       <main className="flex-1 px-6 py-6">
         <div className="max-w-7xl mx-auto flex flex-col gap-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import * as React from "react";
+import Link from "next/link";
 import { InventoryTable } from "@/components/inventory-table";
 import { ProjectSidebar } from "@/components/project-sidebar";
 import { ClaudeMdViewer } from "@/components/claude-md-viewer";
 import { SettingsPanel, loadAdditionalPaths } from "@/components/settings-panel";
-import { Button } from "@/components/ui/button";
+import { useScanContext } from "@/components/scan-context";
 import type { ProjectFilter } from "@/components/project-sidebar";
 import type { SkillFile } from "@/lib/types";
 import type { ScanResponse, ScanErrorResponse } from "@/app/api/scan/route";
+import type { AnalyzeResponse } from "@/app/api/analyze/route";
 
 /** Minimal project info needed to look up paths for the CLAUDE.md viewer. */
 interface ProjectRef {
@@ -21,8 +23,44 @@ type ScanState =
   | { status: "error"; message: string }
   | { status: "ok"; skills: SkillFile[]; projects: ProjectRef[]; scannedAt: string; durationMs: number };
 
+interface DashboardStats {
+  totalSkills: number;
+  overlaps: number;
+  gaps: number;
+  contradictions: number;
+}
+
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
+
+interface StatCardProps {
+  label: string;
+  value: number;
+  href: string;
+  colorClass: string;
+}
+
+function StatCard({ label, value, href, colorClass }: StatCardProps) {
+  return (
+    <Link
+      href={href}
+      className="flex flex-col gap-1 rounded-xl border border-border bg-card px-5 py-4 hover:bg-muted/40 transition-colors"
+    >
+      <span className={`text-3xl font-bold tabular-nums ${colorClass}`}>{value}</span>
+      <span className="text-sm text-muted-foreground">{label}</span>
+    </Link>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
 export default function Home() {
+  const { registerScan } = useScanContext();
   const [scan, setScan] = React.useState<ScanState>({ status: "loading" });
+  const [stats, setStats] = React.useState<DashboardStats | null>(null);
   const [projectFilter, setProjectFilter] = React.useState<ProjectFilter>(null);
   const [additionalPaths, setAdditionalPaths] = React.useState<string[]>([]);
   const [settingsOpen, setSettingsOpen] = React.useState(false);
@@ -32,8 +70,20 @@ export default function Home() {
     setAdditionalPaths(loadAdditionalPaths());
   }, []);
 
+  // Stable ref so the rescan callback passed to registerScan always calls
+  // the current version of runScan without self-referential dependency issues.
+  const runScanRef = React.useRef<((paths: string[]) => Promise<void>) | undefined>(undefined);
+
   const runScan = React.useCallback(async (paths: string[]) => {
     setScan({ status: "loading" });
+
+    // Register loading state with the nav bar (use stable ref for rescan)
+    registerScan({
+      scannedAt: null,
+      scanning: true,
+      rescan: () => { void runScanRef.current?.(paths); },
+    });
+
     try {
       const url =
         paths.length > 0
@@ -43,15 +93,22 @@ export default function Home() {
       if (!res.ok) {
         const errBody = (await res.json()) as ScanErrorResponse;
         setScan({ status: "error", message: errBody.error });
+        registerScan({
+          scannedAt: null,
+          scanning: false,
+          rescan: () => { void runScanRef.current?.(paths); },
+        });
         return;
       }
       const data = (await res.json()) as ScanResponse;
+
       // Flatten all skills from all levels
       const allSkills: SkillFile[] = [
         ...data.projects.flatMap((p) => p.skills),
         ...data.userSkills,
         ...data.pluginSkills,
       ];
+
       setScan({
         status: "ok",
         skills: allSkills,
@@ -59,13 +116,45 @@ export default function Home() {
         scannedAt: data.scannedAt,
         durationMs: data.scanDurationMs,
       });
+
+      // Fetch analyze stats for dashboard summary
+      const analyzeUrl =
+        paths.length > 0
+          ? `/api/analyze?additionalPaths=${encodeURIComponent(paths.join(","))}`
+          : "/api/analyze";
+      const analyzeRes = await fetch(analyzeUrl);
+      if (analyzeRes.ok) {
+        const analyzeData = (await analyzeRes.json()) as AnalyzeResponse;
+        setStats({
+          totalSkills: allSkills.length,
+          overlaps: analyzeData.clusters.length,
+          gaps: analyzeData.gaps.length,
+          contradictions: analyzeData.contradictions.length,
+        });
+      }
+
+      registerScan({
+        scannedAt: data.scannedAt,
+        scanning: false,
+        rescan: () => { void runScanRef.current?.(paths); },
+      });
     } catch (err) {
       setScan({
         status: "error",
         message: err instanceof Error ? err.message : "Unknown error",
       });
+      registerScan({
+        scannedAt: null,
+        scanning: false,
+        rescan: () => { void runScanRef.current?.(paths); },
+      });
     }
-  }, []);
+  }, [registerScan]);
+
+  // Keep the ref in sync with the latest runScan
+  React.useEffect(() => {
+    runScanRef.current = runScan;
+  }, [runScan]);
 
   // Run scan on mount and whenever additionalPaths changes
   React.useEffect(() => {
@@ -77,26 +166,7 @@ export default function Home() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b border-border px-6 py-4 shrink-0">
-        <div className="max-w-7xl mx-auto flex items-center justify-between gap-3">
-          <div className="flex items-baseline gap-3">
-            <h1 className="text-xl font-bold tracking-tight">Skill Lens</h1>
-            <span className="text-sm text-muted-foreground">
-              Claude Code skill inventory
-            </span>
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setSettingsOpen(true)}
-          >
-            Settings
-          </Button>
-        </div>
-      </header>
-
+    <div className="flex flex-col min-h-[calc(100vh-3.5rem)] bg-background">
       {/* Settings panel */}
       <SettingsPanel
         open={settingsOpen}
@@ -106,7 +176,7 @@ export default function Home() {
 
       {/* Main content */}
       <main className="flex-1 px-6 py-6">
-        <div className="max-w-7xl mx-auto flex flex-col gap-4">
+        <div className="max-w-7xl mx-auto flex flex-col gap-6">
           {scan.status === "loading" && (
             <div className="flex flex-col items-center justify-center gap-3 py-20 text-muted-foreground">
               <div className="size-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -122,15 +192,49 @@ export default function Home() {
 
           {scan.status === "ok" && (
             <>
+              {/* Dashboard summary stats */}
+              {stats && (
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                  <StatCard
+                    label="Total skills"
+                    value={stats.totalSkills}
+                    href="/"
+                    colorClass="text-foreground"
+                  />
+                  <StatCard
+                    label="Overlaps"
+                    value={stats.overlaps}
+                    href="/overlaps"
+                    colorClass="text-amber-600 dark:text-amber-400"
+                  />
+                  <StatCard
+                    label="Gaps"
+                    value={stats.gaps}
+                    href="/insights"
+                    colorClass="text-orange-600 dark:text-orange-400"
+                  />
+                  <StatCard
+                    label="Contradictions"
+                    value={stats.contradictions}
+                    href="/insights"
+                    colorClass="text-blue-600 dark:text-blue-400"
+                  />
+                </div>
+              )}
+
+              {/* Scan meta + settings */}
               <div className="flex items-center justify-between">
                 <p className="text-sm text-muted-foreground">
-                  Scanned {scan.skills.length} file
-                  {scan.skills.length !== 1 ? "s" : ""} in{" "}
+                  {scan.skills.length} file
+                  {scan.skills.length !== 1 ? "s" : ""} scanned in{" "}
                   {scan.durationMs}ms
                 </p>
-                <p className="text-xs text-muted-foreground/60">
-                  {new Date(scan.scannedAt).toLocaleTimeString()}
-                </p>
+                <button
+                  onClick={() => setSettingsOpen(true)}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  Manage scan paths
+                </button>
               </div>
 
               {scan.skills.length === 0 ? (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import * as React from "react";
+import { loadAdditionalPaths } from "@/components/settings-panel";
+import { Button } from "@/components/ui/button";
+import type {
+  ValidatePathResponse,
+  ValidatePathErrorResponse,
+} from "@/app/api/validate-path/route";
+
+// ---------------------------------------------------------------------------
+// Storage helpers (duplicated from settings-panel to avoid Sheet dependency)
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = "skill-lens:additionalPaths";
+
+function saveAdditionalPaths(paths: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(paths));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ValidationState =
+  | { status: "idle" }
+  | { status: "validating" }
+  | { status: "error"; message: string }
+  | { status: "ok"; resolvedPath: string };
+
+// ---------------------------------------------------------------------------
+// Settings page
+// ---------------------------------------------------------------------------
+
+export default function SettingsPage() {
+  const [paths, setPaths] = React.useState<string[]>([]);
+  const [input, setInput] = React.useState("");
+  const [validation, setValidation] = React.useState<ValidationState>({
+    status: "idle",
+  });
+
+  // Load saved paths on mount
+  React.useEffect(() => {
+    setPaths(loadAdditionalPaths());
+  }, []);
+
+  async function handleAdd() {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+
+    if (paths.includes(trimmed)) {
+      setValidation({ status: "error", message: "Path already added" });
+      return;
+    }
+
+    setValidation({ status: "validating" });
+
+    try {
+      const res = await fetch("/api/validate-path", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: trimmed }),
+      });
+
+      if (!res.ok) {
+        const body = (await res.json()) as ValidatePathErrorResponse;
+        setValidation({ status: "error", message: body.error });
+        return;
+      }
+
+      const body = (await res.json()) as ValidatePathResponse;
+
+      if (!body.valid) {
+        setValidation({ status: "error", message: body.reason });
+        return;
+      }
+
+      const resolved = body.resolvedPath;
+      const next = paths.includes(resolved) ? paths : [...paths, resolved];
+      setPaths(next);
+      saveAdditionalPaths(next);
+      setInput("");
+      setValidation({ status: "ok", resolvedPath: resolved });
+    } catch (err) {
+      setValidation({
+        status: "error",
+        message: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  }
+
+  function handleRemove(p: string) {
+    const next = paths.filter((x) => x !== p);
+    setPaths(next);
+    saveAdditionalPaths(next);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      void handleAdd();
+    }
+  }
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setInput(e.target.value);
+    if (validation.status !== "idle") {
+      setValidation({ status: "idle" });
+    }
+  }
+
+  return (
+    <div className="flex flex-col min-h-[calc(100vh-3.5rem)] bg-background">
+      <main className="flex-1 px-6 py-8">
+        <div className="max-w-2xl mx-auto flex flex-col gap-8">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Configure additional scan paths and preferences.
+            </p>
+          </div>
+
+          {/* Scan paths section */}
+          <section className="flex flex-col gap-4">
+            <div>
+              <h2 className="text-base font-semibold">Scan Paths</h2>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                Additional directories to scan for skill files. Paths are
+                validated on the server and persisted in your browser.
+              </p>
+            </div>
+
+            {/* Add path input */}
+            <div className="rounded-xl border border-border bg-card p-5 flex flex-col gap-3">
+              <label className="text-sm font-medium">Add a directory path</label>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  placeholder="/home/you/projects/my-repo"
+                  value={input}
+                  onChange={handleInputChange}
+                  onKeyDown={handleKeyDown}
+                  disabled={validation.status === "validating"}
+                  className="flex-1 h-9 rounded-md border border-border bg-background px-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+                />
+                <Button
+                  size="sm"
+                  onClick={() => void handleAdd()}
+                  disabled={!input.trim() || validation.status === "validating"}
+                >
+                  {validation.status === "validating" ? "Checking…" : "Add"}
+                </Button>
+              </div>
+
+              {validation.status === "error" && (
+                <p className="text-xs text-destructive">{validation.message}</p>
+              )}
+              {validation.status === "ok" && (
+                <p className="text-xs text-green-600 dark:text-green-400">
+                  Added: {validation.resolvedPath}
+                </p>
+              )}
+            </div>
+
+            {/* Saved paths list */}
+            <div className="flex flex-col gap-2">
+              <h3 className="text-sm font-medium">
+                Saved paths{" "}
+                <span className="text-muted-foreground font-normal">
+                  ({paths.length})
+                </span>
+              </h3>
+
+              {paths.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-6 text-center border border-dashed border-border rounded-xl">
+                  No additional paths configured
+                </p>
+              ) : (
+                <ul className="flex flex-col gap-2">
+                  {paths.map((p) => (
+                    <li
+                      key={p}
+                      className="flex items-center justify-between gap-2 rounded-lg border border-border bg-muted/20 px-4 py-2.5"
+                    >
+                      <span
+                        className="text-sm font-mono text-foreground/80 break-all flex-1"
+                        title={p}
+                      >
+                        {p}
+                      </span>
+                      <button
+                        onClick={() => handleRemove(p)}
+                        className="shrink-0 text-xs text-muted-foreground hover:text-destructive transition-colors px-1"
+                        aria-label={`Remove ${p}`}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              Changes take effect on your next scan. Use the Re-scan button in
+              the nav bar to apply updated paths immediately.
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useScanContext } from "@/components/scan-context";
+
+interface NavLink {
+  href: string;
+  label: string;
+}
+
+const NAV_LINKS: NavLink[] = [
+  { href: "/", label: "Inventory" },
+  { href: "/overlaps", label: "Overlaps" },
+  { href: "/insights", label: "Insights" },
+  { href: "/settings", label: "Settings" },
+];
+
+export function NavBar() {
+  const pathname = usePathname();
+  const { scannedAt, scanning, rescan } = useScanContext();
+
+  // Determine active link — exact match for "/" to avoid matching everything
+  function isActive(href: string): boolean {
+    if (href === "/") return pathname === "/";
+    return pathname.startsWith(href);
+  }
+
+  return (
+    <header className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shrink-0 sticky top-0 z-40">
+      <div className="max-w-7xl mx-auto px-6 h-14 flex items-center gap-6">
+        {/* Branding */}
+        <Link
+          href="/"
+          className="flex items-center gap-2 font-bold tracking-tight text-foreground hover:text-foreground/80 transition-colors shrink-0"
+        >
+          <span className="text-base">Skill Lens</span>
+        </Link>
+
+        {/* Divider */}
+        <span className="h-5 w-px bg-border shrink-0" aria-hidden="true" />
+
+        {/* Navigation links */}
+        <nav className="flex items-center gap-1" aria-label="Main navigation">
+          {NAV_LINKS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={
+                isActive(href)
+                  ? "inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium bg-foreground/8 text-foreground transition-colors"
+                  : "inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
+              }
+              aria-current={isActive(href) ? "page" : undefined}
+            >
+              {label}
+            </Link>
+          ))}
+        </nav>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Scan status + re-scan button */}
+        <div className="flex items-center gap-3 shrink-0">
+          {scannedAt && (
+            <span className="text-xs text-muted-foreground hidden sm:block">
+              Last scan{" "}
+              <time dateTime={scannedAt}>
+                {new Date(scannedAt).toLocaleTimeString()}
+              </time>
+            </span>
+          )}
+          {rescan && (
+            <button
+              onClick={rescan}
+              disabled={scanning}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-ring"
+              aria-label="Re-scan projects"
+            >
+              {scanning ? (
+                <>
+                  <span className="size-3 animate-spin rounded-full border border-current border-t-transparent" aria-hidden="true" />
+                  Scanning…
+                </>
+              ) : (
+                <>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                    className="size-3"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M13.836 2.477a.75.75 0 0 1 .75.75v3.182a.75.75 0 0 1-.75.75h-3.182a.75.75 0 0 1 0-1.5h1.37l-.84-.841a4.5 4.5 0 0 0-7.08 1.01.75.75 0 1 1-1.3-.75 6 6 0 0 1 9.44-1.347l.842.841V3.227a.75.75 0 0 1 .75-.75Zm-.911 7.5A.75.75 0 0 1 13.199 11a6 6 0 0 1-9.44 1.347l-.842-.841v1.274a.75.75 0 0 1-1.5 0V9.591a.75.75 0 0 1 .75-.75H5.35a.75.75 0 0 1 0 1.5H3.98l.84.841a4.5 4.5 0 0 0 7.08-1.01.75.75 0 0 1 1.025-.195Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  Re-scan
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/scan-context.tsx
+++ b/src/components/scan-context.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * ScanContext — shared scan state for the NavBar re-scan button and status.
+ *
+ * Pages that run their own scans should call `registerScan` to expose
+ * their scannedAt timestamp and trigger function to the NavBar.
+ */
+
+import * as React from "react";
+
+interface ScanContextValue {
+  scannedAt: string | null;
+  scanning: boolean;
+  rescan: (() => void) | null;
+  /** Pages call this to register their scan controls with the layout. */
+  registerScan: (opts: {
+    scannedAt: string | null;
+    scanning: boolean;
+    rescan: () => void;
+  }) => void;
+}
+
+const ScanContext = React.createContext<ScanContextValue>({
+  scannedAt: null,
+  scanning: false,
+  rescan: null,
+  registerScan: () => undefined,
+});
+
+export function ScanProvider({ children }: { children: React.ReactNode }) {
+  const [scannedAt, setScannedAt] = React.useState<string | null>(null);
+  const [scanning, setScanning] = React.useState(false);
+  const rescanRef = React.useRef<(() => void) | null>(null);
+
+  const registerScan = React.useCallback(
+    (opts: { scannedAt: string | null; scanning: boolean; rescan: () => void }) => {
+      setScannedAt(opts.scannedAt);
+      setScanning(opts.scanning);
+      rescanRef.current = opts.rescan;
+    },
+    []
+  );
+
+  const rescan = React.useCallback(() => {
+    rescanRef.current?.();
+  }, []);
+
+  const value = React.useMemo(
+    () => ({ scannedAt, scanning, rescan, registerScan }),
+    [scannedAt, scanning, rescan, registerScan]
+  );
+
+  return <ScanContext.Provider value={value}>{children}</ScanContext.Provider>;
+}
+
+export function useScanContext() {
+  return React.useContext(ScanContext);
+}


### PR DESCRIPTION
## Summary

- Adds a sticky `NavBar` component with links to `/`, `/overlaps`, `/insights`, `/settings`; active-page indicator via `usePathname()`; and a Re-scan button + last-scanned timestamp pulled from `ScanContext`
- Adds `ScanProvider` / `useScanContext` so the home page scan state (scannedAt, scanning, rescan trigger) is shared with the layout-level nav bar without prop-drilling
- Adds 4 dashboard summary stat cards on the landing page (total skills, overlaps, gaps, contradictions) — each links to the relevant page
- Creates `/settings` page that hosts the scan-path manager inline (no longer a slide-over only)
- Removes the old per-page `<header>` elements from `/overlaps` and `/insights` — the shared nav bar now owns branding and navigation

## Test plan

- [ ] Navigate between all 4 pages — active link is highlighted
- [ ] Re-scan button in nav bar triggers a fresh scan; spinner shows while scanning
- [ ] Last-scanned time updates after each scan
- [ ] Dashboard stat cards show correct counts and link correctly
- [ ] `/settings` page allows adding/removing scan paths
- [ ] All 172 existing tests pass (`npm test`)
- [ ] `npx tsc --noEmit` and `npm run lint` are clean

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
