### PR TITLE
fix: show all projects in sidebar including those with 0 skills (#40)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -254,6 +254,7 @@ export default function Home() {
                 <div className="flex flex-col md:flex-row gap-6 items-start">
                   <ProjectSidebar
                     skills={scan.skills}
+                    projects={scan.projects}
                     activeFilter={projectFilter}
                     onFilterChange={setProjectFilter}
                   />

--- a/src/components/project-sidebar.test.ts
+++ b/src/components/project-sidebar.test.ts
@@ -1,18 +1,20 @@
 /**
- * Unit tests for ProjectSidebar utility logic (computeProjectCounts)
+ * Unit tests for ProjectSidebar utility logic (computeProjectCounts, computeProjectCountsWithAllProjects)
  *
  * AC1: "Sidebar lists all projects with counts" → unit (pure count computation)
  * AC2: "Clicking filters the inventory table" → e2e (browser interaction — deferred)
  * AC3: "All Projects clears filter" → e2e (browser interaction — deferred)
  * AC4: "Active filter visually indicated" → e2e (visual rendering — deferred)
  * AC5: "Responsive on narrow screens" → e2e (visual rendering — deferred)
+ * AC6: "Projects with 0 skill files appear in sidebar with count 0" → unit (pure count computation)
  *
- * We unit-test the pure logic: computeProjectCounts, which derives sidebar entries
- * from a flat list of SkillFiles. Browser interaction tests are covered by e2e.
+ * We unit-test the pure logic: computeProjectCounts and computeProjectCountsWithAllProjects,
+ * which derive sidebar entries from a flat list of SkillFiles and an optional full Project list.
+ * Browser interaction tests are covered by e2e.
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeProjectCounts } from './project-sidebar';
+import { computeProjectCounts, computeProjectCountsWithAllProjects } from './project-sidebar';
 import type { SkillFile } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
@@ -131,5 +133,96 @@ describe('computeProjectCounts — total', () => {
     ];
     const result = computeProjectCounts(skills);
     expect(result.total).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeProjectCountsWithAllProjects — AC6: projects with 0 skills appear
+// ---------------------------------------------------------------------------
+
+function makeProject(overrides: Partial<{ name: string; path: string }> = {}): { name: string; path: string } {
+  return {
+    name: 'my-project',
+    path: '/repos/my-project',
+    ...overrides,
+  };
+}
+
+describe('computeProjectCountsWithAllProjects — projects with 0 skills', () => {
+  it('includes projects with 0 skill files when a full project list is provided', () => {
+    const projects = [
+      makeProject({ name: 'has-skills', path: '/repos/has-skills' }),
+      makeProject({ name: 'empty-project', path: '/repos/empty-project' }),
+    ];
+    const skills = [
+      makeSkill({ projectName: 'has-skills', level: 'project' }),
+    ];
+    const result = computeProjectCountsWithAllProjects(skills, projects);
+    expect(result.projects).toHaveLength(2);
+    const emptyProj = result.projects.find((p) => p.name === 'empty-project');
+    expect(emptyProj).toBeDefined();
+    expect(emptyProj?.count).toBe(0);
+  });
+
+  it('shows correct count for projects that do have skills', () => {
+    const projects = [
+      makeProject({ name: 'has-skills', path: '/repos/has-skills' }),
+      makeProject({ name: 'empty-project', path: '/repos/empty-project' }),
+    ];
+    const skills = [
+      makeSkill({ projectName: 'has-skills', level: 'project' }),
+      makeSkill({ projectName: 'has-skills', level: 'project' }),
+    ];
+    const result = computeProjectCountsWithAllProjects(skills, projects);
+    const proj = result.projects.find((p) => p.name === 'has-skills');
+    expect(proj?.count).toBe(2);
+  });
+
+  it('sorts projects alphabetically including empty ones', () => {
+    const projects = [
+      makeProject({ name: 'zebra' }),
+      makeProject({ name: 'alpha' }),
+      makeProject({ name: 'middle' }),
+    ];
+    const result = computeProjectCountsWithAllProjects([], projects);
+    const names = result.projects.map((p) => p.name);
+    expect(names).toEqual(['alpha', 'middle', 'zebra']);
+  });
+
+  it('merges projects from skill files not in the explicit project list', () => {
+    // A skill references a project not in the Project[] list — should still appear
+    const projects = [makeProject({ name: 'known-project' })];
+    const skills = [
+      makeSkill({ projectName: 'known-project', level: 'project' }),
+      makeSkill({ projectName: 'orphan-project', level: 'project' }),
+    ];
+    const result = computeProjectCountsWithAllProjects(skills, projects);
+    const names = result.projects.map((p) => p.name);
+    expect(names).toContain('known-project');
+    expect(names).toContain('orphan-project');
+  });
+
+  it('falls back to skill-derived counts when no project list is passed', () => {
+    const skills = [
+      makeSkill({ projectName: 'proj-a', level: 'project' }),
+    ];
+    // Same behaviour as computeProjectCounts when projects is empty/undefined
+    const result = computeProjectCountsWithAllProjects(skills, []);
+    expect(result.projects).toHaveLength(1);
+    expect(result.projects[0].name).toBe('proj-a');
+  });
+
+  it('includes all three projects even when only one has skills', () => {
+    const projects = [
+      makeProject({ name: 'proj-a' }),
+      makeProject({ name: 'proj-b' }),
+      makeProject({ name: 'proj-c' }),
+    ];
+    const skills = [makeSkill({ projectName: 'proj-b', level: 'project' })];
+    const result = computeProjectCountsWithAllProjects(skills, projects);
+    expect(result.projects).toHaveLength(3);
+    expect(result.projects.find((p) => p.name === 'proj-a')?.count).toBe(0);
+    expect(result.projects.find((p) => p.name === 'proj-b')?.count).toBe(1);
+    expect(result.projects.find((p) => p.name === 'proj-c')?.count).toBe(0);
   });
 });

--- a/src/components/project-sidebar.tsx
+++ b/src/components/project-sidebar.tsx
@@ -55,6 +55,58 @@ export function computeProjectCounts(skills: SkillFile[]): ProjectCounts {
   };
 }
 
+/**
+ * Like computeProjectCounts, but also ensures every project in `allProjects`
+ * appears in the result — even projects that have 0 skill files.
+ *
+ * Projects from `allProjects` that are not referenced by any skill are included
+ * with count 0. Projects referenced in skills but absent from `allProjects` are
+ * also included (merged in from the skill list, as before).
+ *
+ * Accepts a narrow type `{ name: string }[]` so both `Project[]` and `ProjectRef[]`
+ * (page-local type) can be passed without mapping.
+ */
+export function computeProjectCountsWithAllProjects(
+  skills: SkillFile[],
+  allProjects: { name: string }[]
+): ProjectCounts {
+  // Start with skill-derived counts
+  const projectMap = new Map<string, number>();
+  let userCount = 0;
+  let pluginCount = 0;
+
+  for (const skill of skills) {
+    if (skill.level === "user") {
+      userCount++;
+    } else if (skill.level === "plugin") {
+      pluginCount++;
+    } else if (skill.projectName !== null) {
+      projectMap.set(
+        skill.projectName,
+        (projectMap.get(skill.projectName) ?? 0) + 1
+      );
+    }
+  }
+
+  // Ensure every project from the full list is present (with 0 if no skills found)
+  for (const proj of allProjects) {
+    if (!projectMap.has(proj.name)) {
+      projectMap.set(proj.name, 0);
+    }
+  }
+
+  const projects: ProjectCount[] = Array.from(projectMap.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    projects,
+    userCount,
+    pluginCount,
+    total: skills.length,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Filter type
 // ---------------------------------------------------------------------------
@@ -185,6 +237,13 @@ function SidebarContent({ counts, activeFilter, onSelect }: SidebarContentProps)
 export interface ProjectSidebarProps {
   /** All flattened skill files (projects + user + plugin). */
   skills: SkillFile[];
+  /**
+   * Full list of discovered projects from the scan API response.
+   * When provided, projects with 0 skill files will still appear in the sidebar.
+   * If omitted, the sidebar falls back to deriving the project list from skill files only.
+   * Accepts any object with at least a `name` field (compatible with Project and ProjectRef).
+   */
+  projects?: { name: string }[];
   /** Current filter value. */
   activeFilter: ProjectFilter;
   /** Called when the user clicks a sidebar entry. */
@@ -193,11 +252,18 @@ export interface ProjectSidebarProps {
 
 export function ProjectSidebar({
   skills,
+  projects,
   activeFilter,
   onFilterChange,
 }: ProjectSidebarProps) {
   const [mobileOpen, setMobileOpen] = React.useState(false);
-  const counts = React.useMemo(() => computeProjectCounts(skills), [skills]);
+  const counts = React.useMemo(
+    () =>
+      projects !== undefined
+        ? computeProjectCountsWithAllProjects(skills, projects)
+        : computeProjectCounts(skills),
+    [skills, projects]
+  );
 
   function handleSelect(filter: ProjectFilter) {
     onFilterChange(filter);


### PR DESCRIPTION
## Summary

Projects listed in `~/.claude.json` that have no `.claude/skills/` directory were invisible in the sidebar because the sidebar derived its project list solely from the flattened `skills[]` array. This fix ensures all discovered projects appear in the sidebar, with a count of 0 for those with no skill files.

## Changes

- Add `computeProjectCountsWithAllProjects(skills, allProjects)` to `project-sidebar.tsx` — seeds the count map with every project from the full list before applying skill counts, so zero-skill projects always appear with count 0
- Update `ProjectSidebarProps` to accept an optional `projects?: { name: string }[]` prop; when provided the component uses the new function, otherwise falls back to the original `computeProjectCounts`
- Pass `scan.projects` from `page.tsx` to `ProjectSidebar` so the full discovered project list drives the sidebar
- Add 6 new unit tests for `computeProjectCountsWithAllProjects` covering: zero-skill projects appear, correct counts for projects with skills, alphabetical sorting including empty projects, orphan-project merging, and fallback to skill-derived list

## Output Files

- `src/components/project-sidebar.tsx` — new function + updated component props
- `src/components/project-sidebar.test.ts` — new unit tests
- `src/app/page.tsx` — pass `projects` prop to `ProjectSidebar`

## Testing

- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 184 tests, 12 test files, all green

## Acceptance Criteria

- [x] Projects with 0 skill files appear in the sidebar with count 0
- [x] Projects with skills continue to show the correct count
- [x] Sidebar project list is sorted alphabetically
- [x] Backward compatible — callers that don't pass `projects` still work via fallback

Fixes #40

---
Generated with Claude Code
