### PR TITLE
feat: show source location for each copy in overlap cluster cards (#41)

### DIFF
--- a/src/app/api/analyze/route.test.ts
+++ b/src/app/api/analyze/route.test.ts
@@ -40,6 +40,7 @@ function makeSkillFile(overrides: Partial<SkillFile> & { filePath: string }): Sk
     level: 'project',
     projectName: `project-${_counter}`,
     projectPath: `/repos/project-${_counter}`,
+    pluginName: null,
     frontmatter: {},
     body: 'body',
     contentHash: `hash-${_counter}`,

--- a/src/app/overlaps/page.tsx
+++ b/src/app/overlaps/page.tsx
@@ -9,7 +9,8 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { DiffView } from "@/components/diff-view";
-import type { OverlapCluster, SkillFile } from "@/lib/types";
+import { locationLabel } from "@/lib/overlaps-utils";
+import type { OverlapCluster } from "@/lib/types";
 import type { AnalyzeResponse, AnalyzeErrorResponse } from "@/app/api/analyze/route";
 
 // ---------------------------------------------------------------------------
@@ -40,16 +41,6 @@ function StatusBadge({ status }: { status: OverlapCluster["status"] }) {
       identical
     </span>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Location label for a single SkillFile
-// ---------------------------------------------------------------------------
-
-function locationLabel(skill: SkillFile): string {
-  if (skill.level === "user") return "~/.claude (user)";
-  if (skill.level === "plugin") return "plugin";
-  return skill.projectName ?? skill.filePath;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,27 +82,34 @@ function ClusterCard({ cluster, onOpenDiff }: ClusterCardProps) {
         </p>
 
         {/* Location list */}
-        <ul className="flex flex-col gap-1">
+        <ul className="flex flex-col gap-1.5">
           {cluster.files.map((file) => (
             <li
               key={file.filePath}
-              className="flex items-center gap-2 text-xs"
+              className="flex flex-col gap-0.5"
               title={file.filePath}
             >
-              {/* Level badge */}
-              <span
-                className={
-                  file.level === "user"
-                    ? "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 shrink-0"
-                    : file.level === "plugin"
-                      ? "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300 shrink-0"
-                      : "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300 shrink-0"
-                }
-              >
-                {file.level}
-              </span>
-              <span className="truncate text-muted-foreground font-mono">
-                {locationLabel(file)}
+              <div className="flex items-center gap-1.5">
+                {/* Level badge */}
+                <span
+                  className={
+                    file.level === "user"
+                      ? "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 shrink-0"
+                      : file.level === "plugin"
+                        ? "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300 shrink-0"
+                        : "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300 shrink-0"
+                  }
+                >
+                  {file.level}
+                </span>
+                {/* Source name — project/plugin/user identifier */}
+                <span className="text-xs font-medium text-foreground truncate">
+                  {locationLabel(file)}
+                </span>
+              </div>
+              {/* File path — shown in muted mono below the source name */}
+              <span className="text-[10px] font-mono text-muted-foreground truncate pl-0.5">
+                {file.filePath}
               </span>
             </li>
           ))}

--- a/src/components/diff-view.test.ts
+++ b/src/components/diff-view.test.ts
@@ -25,6 +25,7 @@ function makeSkill(overrides: Partial<SkillFile>): SkillFile {
     level: 'user',
     projectName: null,
     projectPath: null,
+    pluginName: null,
     frontmatter: { name: 'Test Skill', description: 'A test skill' },
     body: '# Test Skill\n\nThis is the body.',
     contentHash: 'abc123',

--- a/src/components/diff-view.tsx
+++ b/src/components/diff-view.tsx
@@ -11,6 +11,7 @@
 
 import * as React from "react";
 import { diffLines } from "diff";
+import { locationLabel } from "@/lib/overlaps-utils";
 import type { SkillFile } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -137,8 +138,7 @@ function DiffPanel({
     return "text-foreground";
   }
 
-  const displayProject =
-    skill.projectName ?? (skill.level === "user" ? "~/.claude (user)" : "plugin");
+  const displayProject = locationLabel(skill);
 
   return (
     <div className="flex flex-col flex-1 min-w-0 overflow-hidden border border-border rounded-lg">
@@ -225,8 +225,7 @@ function FileSelector({
       >
         {files.map((file, i) => (
           <option key={file.filePath} value={i}>
-            {file.projectName ?? (file.level === "user" ? "~/.claude (user)" : "plugin")} —{" "}
-            {file.filePath.split(/[\\/]/).pop() ?? file.filePath}
+            {locationLabel(file)} — {file.filePath.split(/[\\/]/).pop() ?? file.filePath}
           </option>
         ))}
       </select>

--- a/src/components/project-sidebar.test.ts
+++ b/src/components/project-sidebar.test.ts
@@ -30,6 +30,7 @@ function makeSkill(overrides: Partial<SkillFile>): SkillFile {
     level: 'project',
     projectName: 'my-app',
     projectPath: '/repos/my-app',
+    pluginName: null,
     frontmatter: {},
     body: '',
     contentHash: 'abc123',

--- a/src/lib/analyzer/contradictions.test.ts
+++ b/src/lib/analyzer/contradictions.test.ts
@@ -34,6 +34,7 @@ function makeSkillFile(
     level: 'project',
     projectName: `project-${_idCounter}`,
     projectPath: `/repos/project-${_idCounter}`,
+    pluginName: null,
     frontmatter,
     body: 'body',
     contentHash: `hash-${_idCounter}`,

--- a/src/lib/analyzer/gaps.test.ts
+++ b/src/lib/analyzer/gaps.test.ts
@@ -31,6 +31,7 @@ function makeSkillFile(overrides: Partial<SkillFile> & { filePath: string }): Sk
     level: 'project',
     projectName: `project-${_idCounter}`,
     projectPath: `/repos/project-${_idCounter}`,
+    pluginName: null,
     frontmatter: {},
     body: 'body',
     contentHash: `hash-${_idCounter}`,

--- a/src/lib/analyzer/overlaps.test.ts
+++ b/src/lib/analyzer/overlaps.test.ts
@@ -26,6 +26,7 @@ function makeSkillFile(overrides: Partial<SkillFile> & { filePath: string }): Sk
     level: 'project',
     projectName: `project-${_idCounter}`,
     projectPath: `/repos/project-${_idCounter}`,
+    pluginName: null,
     frontmatter: {},
     body: 'body',
     contentHash: `hash-${_idCounter}`,

--- a/src/lib/overlaps-utils.test.ts
+++ b/src/lib/overlaps-utils.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for overlap cluster display utilities.
+ *
+ * AC1: "Each copy shows project name, plugin name, or 'User' — not just the level badge"
+ *      → unit (pure display logic, no HTTP/DOM)
+ * AC4: "Plugin-level files show which plugin they belong to (derived from parent directory name)"
+ *      → unit (pure logic)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { locationLabel } from './overlaps-utils';
+import type { SkillFile } from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSkillFile(overrides: Partial<SkillFile> = {}): SkillFile {
+  return {
+    filePath: '/some/path/SKILL.md',
+    name: 'Test Skill',
+    description: '',
+    type: 'skill',
+    level: 'user',
+    projectName: null,
+    projectPath: null,
+    pluginName: null,
+    frontmatter: {},
+    body: '',
+    contentHash: 'abc123',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC1 + AC4: locationLabel
+// ---------------------------------------------------------------------------
+
+describe('locationLabel — user level', () => {
+  it('returns "User" for user-level skills', () => {
+    const skill = makeSkillFile({ level: 'user' });
+    expect(locationLabel(skill)).toBe('User');
+  });
+
+  it('returns "User" even if projectName is set (should not happen, but defensive)', () => {
+    const skill = makeSkillFile({ level: 'user', projectName: 'some-project' });
+    expect(locationLabel(skill)).toBe('User');
+  });
+});
+
+describe('locationLabel — project level', () => {
+  it('returns the project name for project-level skills', () => {
+    const skill = makeSkillFile({
+      level: 'project',
+      projectName: 'my-app',
+      filePath: '/repos/my-app/.claude/skills/save/SKILL.md',
+    });
+    expect(locationLabel(skill)).toBe('my-app');
+  });
+
+  it('falls back to filePath when projectName is null', () => {
+    const skill = makeSkillFile({
+      level: 'project',
+      projectName: null,
+      filePath: '/extra/path/.claude/skills/save/SKILL.md',
+    });
+    expect(locationLabel(skill)).toBe('/extra/path/.claude/skills/save/SKILL.md');
+  });
+});
+
+describe('locationLabel — plugin level', () => {
+  it('returns the plugin name for plugin-level skills (AC4)', () => {
+    const skill = makeSkillFile({
+      level: 'plugin',
+      pluginName: 'my-plugin',
+      filePath: '/home/user/.claude/plugins/my-plugin/skills/save/SKILL.md',
+    });
+    expect(locationLabel(skill)).toBe('my-plugin');
+  });
+
+  it('falls back to filePath when pluginName is null', () => {
+    const skill = makeSkillFile({
+      level: 'plugin',
+      pluginName: null,
+      filePath: '/home/user/.claude/plugins/unknown-plugin/SKILL.md',
+    });
+    expect(locationLabel(skill)).toBe('/home/user/.claude/plugins/unknown-plugin/SKILL.md');
+  });
+});

--- a/src/lib/overlaps-utils.ts
+++ b/src/lib/overlaps-utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared display utilities for overlap cluster rendering.
+ *
+ * This module is pure — no server-only or browser-only dependencies,
+ * so it can be imported from both server components and client components.
+ */
+
+import type { SkillFile } from './types';
+
+/**
+ * Returns a human-readable source label for a SkillFile copy in a cluster:
+ * - user-level  → "User"
+ * - plugin-level → plugin name (e.g. "my-plugin"), fallback to filePath
+ * - project-level → project name (e.g. "my-app"), fallback to filePath
+ */
+export function locationLabel(skill: SkillFile): string {
+  if (skill.level === 'user') return 'User';
+  if (skill.level === 'plugin') return skill.pluginName ?? skill.filePath;
+  return skill.projectName ?? skill.filePath;
+}

--- a/src/lib/parser/parse.ts
+++ b/src/lib/parser/parse.ts
@@ -58,12 +58,14 @@ function deriveName(filePath: string): string {
  * @param level       Scope level: 'user' | 'project' | 'plugin'.
  * @param projectName Optional name of the owning project.
  * @param projectPath Optional absolute path to the owning project root.
+ * @param pluginName  Optional name of the plugin (directory name under ~/.claude/plugins/).
  */
 export function parseSkillFile(
   filePath: string,
   level: SkillFile['level'],
   projectName: string | null = null,
-  projectPath: string | null = null
+  projectPath: string | null = null,
+  pluginName: string | null = null
 ): SkillFile {
   // 1. Read file content
   const raw = fs.readFileSync(filePath, 'utf-8');
@@ -106,6 +108,7 @@ export function parseSkillFile(
     level,
     projectName,
     projectPath,
+    pluginName,
     frontmatter,
     body,
     contentHash,

--- a/src/lib/scanner/scan.test.ts
+++ b/src/lib/scanner/scan.test.ts
@@ -52,6 +52,7 @@ function makeSkillFile(overrides: Partial<SkillFile> = {}): SkillFile {
     level: 'user',
     projectName: null,
     projectPath: null,
+    pluginName: null,
     frontmatter: {},
     body: 'body',
     contentHash: 'abc123',
@@ -182,7 +183,8 @@ describe('scanAll — project-level scanning', () => {
       '/repos/my-app/.claude/skills/cool-skill/SKILL.md',
       'project',
       'my-app',
-      '/repos/my-app'
+      '/repos/my-app',
+      null
     );
   });
 });
@@ -236,6 +238,7 @@ describe('scanAll — user-level scanning', () => {
       '/home/testuser/.claude/skills/my-skill/SKILL.md',
       'user',
       null,
+      null,
       null
     );
   });
@@ -273,6 +276,7 @@ describe('scanAll — plugin-level scanning', () => {
     const pluginFile = makeSkillFile({
       filePath: '/home/testuser/.claude/plugins/my-plugin/SKILL.md',
       level: 'plugin',
+      pluginName: 'my-plugin',
     });
 
     // Return the plugin file only when the pattern includes "plugins", empty otherwise
@@ -290,6 +294,39 @@ describe('scanAll — plugin-level scanning', () => {
 
     expect(result.pluginSkills).toHaveLength(1);
     expect(result.pluginSkills[0].level).toBe('plugin');
+  });
+
+  it('calls parseSkillFile with pluginName derived from parent directory (AC4)', async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockFs.readdirSync.mockReturnValue([{ name: 'my-plugin', isDirectory: () => true }] as any);
+
+    const pluginFile = makeSkillFile({
+      filePath: '/home/testuser/.claude/plugins/my-plugin/SKILL.md',
+      level: 'plugin',
+      pluginName: 'my-plugin',
+    });
+
+    mockFg.mockImplementation(async (patterns: string | string[]) => {
+      const patternList = Array.isArray(patterns) ? patterns : [patterns];
+      if (patternList.some((p) => p.includes('plugins'))) {
+        return ['/home/testuser/.claude/plugins/my-plugin/SKILL.md'];
+      }
+      return [];
+    });
+
+    mockParseSkillFile.mockReturnValue(pluginFile);
+
+    await scanAll([]);
+
+    // Should call parseSkillFile with the plugin name
+    expect(mockParseSkillFile).toHaveBeenCalledWith(
+      '/home/testuser/.claude/plugins/my-plugin/SKILL.md',
+      'plugin',
+      null,
+      null,
+      'my-plugin'
+    );
   });
 
   it('skips plugin scanning when ~/.claude/plugins does not exist', async () => {

--- a/src/lib/scanner/scan.ts
+++ b/src/lib/scanner/scan.ts
@@ -53,10 +53,11 @@ function safeParse(
   filePath: string,
   level: SkillFile['level'],
   projectName: string | null,
-  projectPath: string | null
+  projectPath: string | null,
+  pluginName: string | null = null
 ): SkillFile | null {
   try {
-    return parseSkillFile(filePath, level, projectName, projectPath);
+    return parseSkillFile(filePath, level, projectName, projectPath, pluginName);
   } catch {
     return null;
   }
@@ -135,13 +136,13 @@ async function scanPluginLevel(homeDir: string): Promise<SkillFile[]> {
     return [];
   }
 
-  const pluginDirs = entries
+  const pluginEntries = entries
     .filter((e) => e.isDirectory())
-    .map((e) => path.join(pluginsDir, e.name).replace(/\\/g, '/'));
+    .map((e) => ({ name: e.name, dir: path.join(pluginsDir, e.name).replace(/\\/g, '/') }));
 
   const skills: SkillFile[] = [];
 
-  for (const pluginDir of pluginDirs) {
+  for (const { name: pluginName, dir: pluginDir } of pluginEntries) {
     // Plugins may keep skills/agents directly in root or under .claude/ subdirs
     const patterns = [
       `${pluginDir}/**/*.md`,
@@ -149,7 +150,7 @@ async function scanPluginLevel(homeDir: string): Promise<SkillFile[]> {
 
     const filePaths = await safeGlob(patterns);
     for (const filePath of filePaths) {
-      const parsed = safeParse(filePath, 'plugin', null, null);
+      const parsed = safeParse(filePath, 'plugin', null, null, pluginName);
       if (parsed) {
         skills.push(parsed);
       }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -33,6 +33,12 @@ export interface SkillFile {
   /** Absolute path to the owning project root, or null for user-level / plugin files. */
   projectPath: string | null;
 
+  /**
+   * Name of the plugin this file belongs to (the directory name under ~/.claude/plugins/),
+   * or null for user-level and project-level files.
+   */
+  pluginName: string | null;
+
   /** Raw YAML frontmatter parsed from the file (all fields). */
   frontmatter: Record<string, unknown>;
 


### PR DESCRIPTION
## Summary

Adds a `pluginName` field to `SkillFile`, populates it during plugin scanning, and updates the Overlaps page cluster cards to display the project name, plugin name, or "User" prominently alongside the file path for each copy — making every entry distinguishable at a glance.

## Changes

- `src/lib/types.ts` — added `pluginName: string | null` field to `SkillFile`
- `src/lib/parser/parse.ts` — added optional `pluginName` parameter (5th arg), included in returned object
- `src/lib/scanner/scan.ts` — `scanPluginLevel` now passes the plugin directory name as `pluginName` to `safeParse`/`parseSkillFile` for each plugin; `safeParse` signature updated
- `src/lib/overlaps-utils.ts` — new shared utility exporting `locationLabel(skill)`: returns "User" for user-level, plugin name for plugin-level, project name for project-level
- `src/app/overlaps/page.tsx` — imports `locationLabel` from shared util (removed local version); cluster card copy list now shows source name prominently + file path on a second line
- `src/components/diff-view.tsx` — imports `locationLabel` from shared util; replaces inline `projectName ?? "plugin"` fallback with consistent display
- All test `makeSkillFile`/`makeSkill` helpers updated to include `pluginName: null`
- `src/lib/scanner/scan.test.ts` — updated `toHaveBeenCalledWith` assertions for 5-arg signature; added test that scanner passes plugin name
- `src/lib/overlaps-utils.test.ts` — new unit tests for `locationLabel`

## Output Files

- `src/lib/types.ts`
- `src/lib/parser/parse.ts`
- `src/lib/scanner/scan.ts`
- `src/lib/overlaps-utils.ts` (new)
- `src/lib/overlaps-utils.test.ts` (new)
- `src/app/overlaps/page.tsx`
- `src/components/diff-view.tsx`

## Testing

- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 191/191

## Acceptance Criteria

- [x] Each copy in a cluster card shows the project name, plugin name, or "User" — not just the level badge
- [x] File path visible for each copy (shown inline below the source name)
- [x] Copies are distinguishable from each other at a glance
- [x] Plugin-level files show which plugin they belong to (derived from parent directory name via `pluginName` field)

Fixes #41

---
Generated with Claude Code
