### PR TITLE
fix: show user-level skills when filtering by project

### DIFF
--- a/src/components/inventory-table.tsx
+++ b/src/components/inventory-table.tsx
@@ -230,7 +230,9 @@ export function InventoryTable({ skills, projectFilter, initialSearch = "", over
       } else if (projectFilter === "__plugin__") {
         result = result.filter((s) => s.level === "plugin");
       } else {
-        result = result.filter((s) => s.projectName === projectFilter);
+        // Include both project-level skills for this project AND user-level skills
+        // (user-level skills are active in every project)
+        result = result.filter((s) => s.projectName === projectFilter || s.level === "user");
       }
     }
 

--- a/src/lib/filter-skills.test.ts
+++ b/src/lib/filter-skills.test.ts
@@ -50,15 +50,22 @@ describe('filterSkillsByProject', () => {
     expect(result[0].level).toBe('plugin');
   });
 
-  it('returns only skills from named project', () => {
+  it('returns project-level AND user-level skills for a named project', () => {
     const result = filterSkillsByProject(allSkills, 'app-a');
-    expect(result).toHaveLength(1);
-    expect(result[0].projectName).toBe('app-a');
+    expect(result).toHaveLength(2);
+    expect(result.some((s) => s.projectName === 'app-a')).toBe(true);
+    expect(result.some((s) => s.level === 'user')).toBe(true);
   });
 
-  it('returns empty array when no skills match the named project', () => {
+  it('returns only user-level skills when no project-level skills match', () => {
     const result = filterSkillsByProject(allSkills, 'nonexistent');
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe('user');
+  });
+
+  it('does not include plugin-level skills when filtering by project', () => {
+    const result = filterSkillsByProject(allSkills, 'app-a');
+    expect(result.every((s) => s.level !== 'plugin')).toBe(true);
   });
 
   it('does not mutate the original array', () => {

--- a/src/lib/filter-skills.ts
+++ b/src/lib/filter-skills.ts
@@ -18,5 +18,7 @@ export function filterSkillsByProject(
   if (filter === null) return skills;
   if (filter === "__user__") return skills.filter((s) => s.level === "user");
   if (filter === "__plugin__") return skills.filter((s) => s.level === "plugin");
-  return skills.filter((s) => s.projectName === filter);
+  // Include both project-level skills for this project AND user-level skills
+  // (user-level skills are active in every project)
+  return skills.filter((s) => s.projectName === filter || s.level === "user");
 }


### PR DESCRIPTION
## Summary
- When selecting a project in the sidebar, user-level skills now appear alongside project-level skills
- User-level skills are active in every project so they should always be visible
- Default sort groups by level (user first, then project) creating a clear hierarchy
- Fixes #67

## Test plan
- [x] Updated filterSkillsByProject tests to verify user-level inclusion
- [x] All 323 tests pass
- [x] Lint clean

Generated with [Claude Code](https://claude.com/claude-code)
